### PR TITLE
Append to members array instead of overwriting property

### DIFF
--- a/api/verify-token.ts
+++ b/api/verify-token.ts
@@ -128,7 +128,7 @@ export default async (req: NowRequest, res: NowResponse) => {
     .catch((error) => {
       console.error(error);
       return res.json({
-        statusCode: 200,
+        statusCode: 500,
         body: JSON.stringify({error}),
       });
     });


### PR DESCRIPTION
Overwriting will likely cause issues if two agents log in at the same time. This patch is not tested.