### PR TITLE
Set initial `person` document as hidden

### DIFF
--- a/api/callback.ts
+++ b/api/callback.ts
@@ -93,6 +93,8 @@ export default async function callback(req, res) {
             github: githubHandle, // not included in Sanity user session
           } : undefined,
           imageUrl: user.userImage,
+          // Avoid the initial barebones profile from being indexable:
+          hidden: true,
           // Let's not add the email by default for now as that'll be public
           // email: user.userEmail,
         }

--- a/schemas/documents/person.js
+++ b/schemas/documents/person.js
@@ -28,7 +28,7 @@ export default {
   type: 'document',
   icon: () => <Icon emoji="👤" />,
   initialValue: {
-    hidden: false,
+    hidden: true,
   },
   fields: [
     {


### PR DESCRIPTION
Before, new user profiles were being created without the `hidden` property, meaning their profile got immediately indexed in `community/people` . 

This PR fixes that by adding `hidden: true` to the initial barebones document.