### PR TITLE
Validating starters

### DIFF
--- a/api/validate-starter.ts
+++ b/api/validate-starter.ts
@@ -1,0 +1,13 @@
+import {NowRequest, NowResponse} from '@now/node';
+import fetch from 'node-fetch';
+
+export default async (req: NowRequest, res: NowResponse) => {
+  const {repoId} = req.query;
+
+  if (!repoId) {
+    return res.status(400).end('No repoID provided');
+  }
+
+  const createRes = await fetch(`https://www.sanity.io/create?template=${repoId}`);
+  return res.status(createRes.status).end("");
+};

--- a/schemas/documents/contributions/starter.js
+++ b/schemas/documents/contributions/starter.js
@@ -1,7 +1,97 @@
+import React from 'react';
 import {RocketIcon} from '@sanity/icons';
+import {withDocument} from 'part:@sanity/form-builder';
 
 import PathInput from '../../components/PathInput';
-import {contributionInitialValue, getContributionTaxonomies, ogImageField, publishedAtField} from './contributionUtils';
+import {
+  contributionInitialValue,
+  getContributionTaxonomies,
+  ogImageField,
+  publishedAtField,
+} from './contributionUtils';
+
+const NAME_REGEX = new RegExp(/[^\/]*\/sanity-template/g);
+
+function testName(name = '') {
+  return NAME_REGEX.test(name);
+}
+
+/**
+ * Used to point contributors to de docs on sanity.io/create
+ */
+class EditorMessage extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      createError: undefined,
+      lastRepoIdFetched: '',
+      loadingRepoId: false,
+    };
+  }
+
+  focus = () => {};
+
+  componentWillUnmount() {
+    window._starterValidity = undefined;
+  }
+
+  render() {
+    const {document} = this.props;
+
+    const nameValidity = testName(document.repoId);
+    const manifestValidity = window._starterValidity;
+
+    console.log({props: this.props, document});
+    return (
+      <div>
+        <h2>How to prepare your starter</h2>
+        <p>
+          We're thrilled to have your contribution - we are sure it'll help many to get started
+          faster and better.
+        </p>
+        <p>
+          In order to have your started listed in Sanity.io, however, we need it to follow a few
+          steps outlined in the{' '}
+          <a href="https://www.sanity.io/docs/starter-templates" target="_blank">
+            starter templates
+          </a>{' '}
+          documentation.
+        </p>
+        {/* {(!nameValidity || manifestValidity === false) && (
+          <div>
+            <h3>Error(s) we spotted with your starter:</h3>
+            <ul>
+              {!nameValidity && (
+                <li>
+                  Repository name doesn't start with <code>sanity-template</code> (
+                  <a
+                    href="https://www.sanity.io/docs/starter-templates#3a1ad2e88585"
+                    target="_blank"
+                  >
+                    more info
+                  </a>
+                  )
+                </li>
+              )}
+              {manifestValidity === false && (
+                <li>
+                  Unable to resolve template manifest (
+                  <a
+                    href="https://www.sanity.io/docs/starter-templates#15d9212bd69b"
+                    target="_blank"
+                  >
+                    more info
+                  </a>
+                  )
+                </li>
+              )}
+            </ul>
+          </div>
+        )} */}
+      </div>
+    );
+  }
+}
 
 export default {
   title: 'Starter',
@@ -37,16 +127,41 @@ export default {
         basePath: 'sanity.io/starters',
         source: 'title',
       },
+      hidden: true,
     },
-    ogImageField,
-    publishedAtField,
+    {
+      name: 'ignoreMe',
+      title: 'Message for editors',
+      type: 'string',
+      readOnly: true,
+      inputComponent: withDocument(EditorMessage),
+    },
     {
       title: 'Github repository ID',
       name: 'repoId',
       description:
-        'The repo ID or slug from your starter’s GitHub repository (eg. sanity-io/some-template)',
+        'The repo ID or slug from your starter’s GitHub repository (eg. sanity-io/sanity-template-example)',
       type: 'string',
-      validation: (Rule) => Rule.required().regex(/^[\w-]+\/[\w-]+$/, {name: 'repo id'}),
+      validation: (Rule) => [
+        Rule.required().regex(/^[\w-]+\/[\w-]+$/, {name: 'repo id'}),
+        // Ensure repo is named correctly
+        Rule.required()
+          .regex(NAME_REGEX)
+          .error('The repository name must start with sanity-template'),
+        // Ensure repo is compatible with sanity.io/create
+        Rule.custom(async (repoId) => {
+          if (!repoId) {
+            return true;
+          }
+          const res = await fetch(`/api/validate-starter?repoId=${repoId}`);
+          if (res.status === 200) {
+            window._starterValidity = true;
+            return true;
+          }
+          window._starterValidity = false;
+          return "Couldn't validate manifest file for this starter";
+        }),
+      ],
     },
     {
       title: '📷 Main image',
@@ -71,11 +186,12 @@ export default {
         },
       ],
     },
+    ogImageField,
+    publishedAtField,
     ...getContributionTaxonomies('starter', {
       solutions: {
         title: 'Categories',
-        description:
-          'Connect your starter to common themes in the Sanity community.',
+        description: 'Connect your starter to common themes in the Sanity community.',
       },
       categories: {
         title: 'Categories',

--- a/schemas/documents/contributions/starter.js
+++ b/schemas/documents/contributions/starter.js
@@ -45,11 +45,11 @@ class EditorMessage extends React.Component {
       <div>
         <h2>How to prepare your starter</h2>
         <p>
-          We're thrilled to have your contribution - we are sure it'll help many to get started
-          faster and better.
+          We're thrilled to have your contribution - we are sure it'll help many people to get
+          started quickly!
         </p>
         <p>
-          In order to have your started listed in Sanity.io, however, we need it to follow a few
+          In order to have your started listed in Sanity.io, however, we need it to follow a the
           steps outlined in the{' '}
           <a href="https://www.sanity.io/docs/starter-templates" target="_blank">
             starter templates
@@ -57,9 +57,10 @@ class EditorMessage extends React.Component {
           documentation.
         </p>
         <p>
-          If your contribution cannot meet these guidelines, that's ok! You can add it as a showcase
-          project by clicking on the "Project for the showcase" item in the main desk menu of this
-          studio.
+          If your contribution cannot meet these guidelines, that's OK! You can add it as a showcase
+          project by clicking on the{' '}
+          <a href="/desk/contribution.showcaseProject" target="_blank">"Project for the showcase" item</a> in the
+          main desk menu of this studio.
         </p>
         {(!nameValidity || manifestValidity === false) && (
           <div>

--- a/schemas/documents/contributions/starter.js
+++ b/schemas/documents/contributions/starter.js
@@ -41,7 +41,6 @@ class EditorMessage extends React.Component {
     const nameValidity = testName(document.repoId);
     const manifestValidity = window._starterValidity;
 
-    console.log({props: this.props, document});
     return (
       <div>
         <h2>How to prepare your starter</h2>
@@ -57,7 +56,12 @@ class EditorMessage extends React.Component {
           </a>{' '}
           documentation.
         </p>
-        {/* {(!nameValidity || manifestValidity === false) && (
+        <p>
+          If your contribution cannot meet these guidelines, that's ok! You can add it as a showcase
+          project by clicking on the "Project for the showcase" item in the main desk menu of this
+          studio.
+        </p>
+        {(!nameValidity || manifestValidity === false) && (
           <div>
             <h3>Error(s) we spotted with your starter:</h3>
             <ul>
@@ -75,19 +79,15 @@ class EditorMessage extends React.Component {
               )}
               {manifestValidity === false && (
                 <li>
-                  Unable to resolve template manifest (
-                  <a
-                    href="https://www.sanity.io/docs/starter-templates#15d9212bd69b"
-                    target="_blank"
-                  >
-                    more info
+                  Sanity.io/create couldn't validate your template. Refer to
+                  <a href="https://www.sanity.io/docs/starter-templates" target="_blank">
+                    the starter templates documentation.
                   </a>
-                  )
                 </li>
               )}
             </ul>
           </div>
-        )} */}
+        )}
       </div>
     );
   }
@@ -159,7 +159,7 @@ export default {
             return true;
           }
           window._starterValidity = false;
-          return "Couldn't validate manifest file for this starter";
+          return "Sanity.io/create couldn't validate your template.";
         }),
       ],
     },


### PR DESCRIPTION
Hey Lauren 👋

This PR adds a message to starters to let authors know Sanity starters need a special treatments before they can be published. It points authors to the starter template docs and offers the showcase as an alternative place for their non-conforming starter.

![image](https://user-images.githubusercontent.com/27744332/113329239-b5383500-92f3-11eb-8278-d86bcbc27277.png)

Would love your take on the wording above, and if you are curious about the implementation let me know :)