### PR TITLE
Add banner block to simple block content

### DIFF
--- a/schemas/documents/taxonomies/getTaxonomy.js
+++ b/schemas/documents/taxonomies/getTaxonomy.js
@@ -86,7 +86,7 @@ const getTaxonomyFields = ({type, includeSlug = true, includeIndexable = true} =
       title: 'Rich text below the header title',
       description:
         '❓ Optional. Use this if you want to clarify or entice visitors about the current taxonomy',
-      type: 'simpleBlockContent',
+      type: 'simpleBlockContentWithBanner',
     },
     {
       name: 'seoTitle',

--- a/schemas/objects/adBanner.js
+++ b/schemas/objects/adBanner.js
@@ -1,0 +1,28 @@
+export default {
+  title: 'Ad Banner',
+  name: 'adBanner',
+  type: 'object',
+  fields: [
+    {
+      title: 'Body',
+      name: 'body',
+      type: 'simpleBlockContent',
+    },
+  ],
+  preview: {
+    select: {
+      body: 'body',
+    },
+    prepare({body}) {
+      const block = (body || []).find((subBlock) => subBlock._type === 'block');
+      return {
+        title: block
+          ? block.children
+              .filter((child) => child._type === 'span')
+              .map((span) => span.text)
+              .join('')
+          : 'No title',
+      };
+    },
+  },
+};

--- a/schemas/objects/simpleBlockContent.js
+++ b/schemas/objects/simpleBlockContent.js
@@ -1,4 +1,4 @@
-export default {
+const simpleBlockContent = {
   title: 'Simple Block Content',
   name: 'simpleBlockContent',
   type: 'array',
@@ -32,3 +32,44 @@ export default {
     },
   ],
 };
+
+export const simpleBlockContentWithBanner = {
+  title: 'Simple Block Content With Banner',
+  name: 'simpleBlockContentWithBanner',
+  type: 'array',
+  of: [
+    {
+      title: 'Block',
+      type: 'block',
+      styles: [],
+      marks: {
+        decorators: [
+          {title: 'Strong', value: 'strong'},
+          {title: 'Emphasis', value: 'em'},
+          // {title: 'Italic', value: 'italic'},
+          {title: 'Code', value: 'code'},
+        ],
+        annotations: [
+          {
+            title: 'URL',
+            name: 'link',
+            type: 'object',
+            fields: [
+              {
+                title: 'URL',
+                name: 'href',
+                type: 'url',
+              },
+            ],
+          },
+        ],
+      },
+    },
+    {
+      name: 'adBanner',
+      type: 'adBanner',
+    },
+  ],
+};
+
+export default simpleBlockContent;

--- a/schemas/schema.js
+++ b/schemas/schema.js
@@ -15,6 +15,7 @@ import taxonomies from './documents/taxonomies';
 import techPartner from './documents/techPartner';
 
 import authors from './objects/authors';
+import adBanner from './objects/adBanner';
 import emojiEntry from './objects/emojiEntry';
 import emojiSummary from './objects/emojiSummary';
 import message from './objects/message';
@@ -23,7 +24,7 @@ import simpleStats from './objects/simpleStats';
 import tag from './objects/tag';
 import richText from './objects/richText';
 import studioImage from './objects/studioImage';
-import simpleBlockContent from './objects/simpleBlockContent';
+import simpleBlockContent, {simpleBlockContentWithBanner} from './objects/simpleBlockContent';
 import contributions from './documents/contributions';
 import curatedContribution from './documents/contributions/curatedContribution';
 import studioTutorials from './documents/studioTutorials';
@@ -61,6 +62,7 @@ export default createSchema({
     landingGetStarted,
 
     // Object types
+    adBanner,
     guideBody,
     authors,
     emojiEntry,
@@ -72,11 +74,12 @@ export default createSchema({
     tag,
     richText,
     simpleBlockContent,
+    simpleBlockContentWithBanner,
     schemaEntryObj,
     youtube,
     callout,
     figure,
     ...taxonomies,
-    ...contributionTypeSections
+    ...contributionTypeSections,
   ]),
 });


### PR DESCRIPTION
Add section on exchange section to allow for text (+ link) as part of the get-started initiative 

<img width="492" alt="image" src="https://user-images.githubusercontent.com/6951139/167128281-5665a89e-0301-43da-abf5-5cc07c3986c4.png">

Co-authored-by: Fred Carlsen <sjelfull@users.noreply.github.com>