### PR TITLE
feat: validation for studio version fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,9 @@
     "sanity-mobile-preview": "^1.0.7",
     "sanity-plugin-markdown": "^1.0.1",
     "sanity-plugin-social-preview": "^0.1.3",
-    "styled-components": "^5.3.3"
+    "semver": "^7.3.7",
+    "styled-components": "^5.3.3",
+    "validate-npm-package-name": "^4.0.0"
   },
   "devDependencies": {
     "@types/dotenv": "^8.2.0",

--- a/schemas/documents/contributions/tool.js
+++ b/schemas/documents/contributions/tool.js
@@ -211,7 +211,7 @@ export default {
       description:
         'In case your code can be installed with one command. E.g. "npm i  @sanity/client", "cargo install sanity"',
       fieldset: 'code',
-      hidden: ({document}) => document.studioVersion >= 2,
+      hidden: ({document, value}) => !value && document.studioVersion >= 2,
     },
     {
       name: 'packageName',
@@ -219,7 +219,8 @@ export default {
       title: 'NPM package name',
       description: 'Used for generating info like "Installation command", links, etc.',
       fieldset: 'code',
-      hidden: ({document}) => document.studioVersion < 2,
+      hidden: ({document}) =>
+        typeof document.studioVersion !== 'number' || document.studioVersion < 2,
       validation: (Rule) =>
         Rule.custom((value, {document}) => {
           if (typeof document.studioVersion !== 'number' || document.studioVersion < 2) {
@@ -274,6 +275,34 @@ export default {
             return `dist-tag can only contain URL-friendly characters`;
           }
 
+          return true;
+        }),
+    },
+    {
+      name: 'v3ReadmeUrl',
+      type: 'url',
+      title: 'Link to v3 readme',
+      description: `This URL will add a link just above the v3 install snippet. For example "https://github.com/sanity-io/sanity-plugin-scheduled-publishing/blob/v3/README.md"`,
+      fieldset: 'code',
+      hidden: ({document}) => document.studioVersion !== 2,
+    },
+    {
+      name: 'v3InstallWith',
+      type: 'string',
+      title: 'Override installation command',
+      description:
+        'If the generated install command is not correct, you can override it here. E.g. "npm i sanity-plugin-media@v3-studio @mdx-js/react"',
+      fieldset: 'code',
+      hidden: ({document}) => document.studioVersion !== 2,
+      validation: (Rule) =>
+        Rule.custom((value, {document}) => {
+          if (document.studioVersion !== 2 || typeof value !== 'string' || !value) {
+            return true;
+          }
+          // Validate the version tag the same npm will when someone attempts using the generated install command in the listing
+          if (value.endsWith(` ${document.packageName}@${document.v3DistTag}`)) {
+            return 'This is the default value, no need to override it';
+          }
           return true;
         }),
     },

--- a/schemas/documents/contributions/tool.js
+++ b/schemas/documents/contributions/tool.js
@@ -177,7 +177,7 @@ export default {
       validation: (Rule) =>
         Rule.custom((value, {document}) => {
           // Handle cases where something should be a studio v2 listing but is still using the old format
-          if (value === -1) {
+          if (typeof value !== 'number' || value === -1) {
             const {installWith, packageUrl = ''} = document;
             if (typeof installWith !== 'string' || !installWith) {
               return true;

--- a/schemas/documents/contributions/tool.js
+++ b/schemas/documents/contributions/tool.js
@@ -1,6 +1,10 @@
 import {PlugIcon} from '@sanity/icons';
 import client from 'part:@sanity/base/client';
 
+import isValidSemver from 'semver/functions/valid';
+import cleanSemver from 'semver/functions/clean';
+import incSemver from 'semver/functions/inc';
+import validateNpmPackageName from 'validate-npm-package-name';
 import brandColorList from '../../../src/utils/brandColorList';
 import PathInput from '../../components/PathInput';
 import {
@@ -139,7 +143,7 @@ export default {
 
             const finalUrl = `https://raw.githubusercontent.com/${repoId}/${filePath}`;
 
-            client
+            return client
               .patch(document._id)
               .set({
                 readmeUrl: finalUrl,
@@ -170,6 +174,26 @@ export default {
           {value: 3, title: 'Studio v3'},
         ],
       },
+      validation: (Rule) =>
+        Rule.custom((value, {document}) => {
+          // Handle cases where something should be a studio v2 listing but is still using the old format
+          if (value === -1) {
+            const {installWith, packageUrl = ''} = document;
+            if (typeof installWith !== 'string' || !installWith) {
+              return true;
+            }
+            // If it's a `sanity install` command we want the author to instead set the `Studio version` and specify compat
+            if (installWith.startsWith('sanity install')) {
+              const [, , origin, , ...parts] = packageUrl.split('/');
+              return `Set the Studio version to "2"${
+                origin === 'www.npmjs.com' && parts.length === 2
+                  ? ` and set "NPM package name" to "${parts.join('/')}"`
+                  : ''
+              } instead of manually specifiying "${installWith}"`;
+            }
+          }
+          return true;
+        }),
     },
     {
       name: 'packageUrl',
@@ -185,17 +209,48 @@ export default {
       type: 'string',
       title: 'Installation command',
       description:
-        'In case your code can be installed with one command. E.g. "sanity install media", "npm i  @sanity/client", "cargo install sanity"',
+        'In case your code can be installed with one command. E.g. "npm i  @sanity/client", "cargo install sanity"',
       fieldset: 'code',
       hidden: ({document}) => document.studioVersion >= 2,
     },
     {
       name: 'packageName',
       type: 'string',
-      title: 'NPM Package name',
+      title: 'NPM package name',
       description: 'Used for generating info like "Installation command", links, etc.',
       fieldset: 'code',
       hidden: ({document}) => document.studioVersion < 2,
+      validation: (Rule) =>
+        Rule.custom((value, {document}) => {
+          if (typeof document.studioVersion !== 'number' || document.studioVersion < 2) {
+            return true;
+          }
+          if (typeof value !== 'string' || !value) {
+            return 'Required';
+          }
+          if (isValidSemver(cleanSemver(value), {loose: true})) {
+            return `name can't be a version string`;
+          }
+          if (value.startsWith('https://www.npmjs.com/package/')) {
+            const packageName = value.replace('https://www.npmjs.com/package/', '');
+            const validation = validateNpmPackageName(packageName);
+            if (validation.validForNewPackages) {
+              return client
+                .patch(document._id)
+                .set({packageName})
+                .commit()
+                .then(() => {
+                  return true;
+                });
+            }
+          }
+          const validation = validateNpmPackageName(value);
+          return Array.isArray(validation.errors)
+            ? validation.errors[0]
+            : Array.isArray(validation.warnings)
+            ? validation.warnings[0]
+            : true;
+        }),
     },
     {
       name: 'v3DistTag',
@@ -204,6 +259,23 @@ export default {
       description: `If you've published a v3 ready version that can be installed using "npm install plugin-name@studio-v3" then enter "studio-v3" below.`,
       fieldset: 'code',
       hidden: ({document}) => document.studioVersion !== 2,
+      validation: (Rule) =>
+        Rule.custom((value, {document}) => {
+          if (document.studioVersion !== 2 || typeof value !== 'string' || !value) {
+            return true;
+          }
+          // Validate the version tag the same npm will when someone attempts using the generated install command in the listing
+          if (isValidSemver(cleanSemver(value))) {
+            return `Use a dist-tag name, like "studio-v3", instead of a version number"`;
+          }
+          // A valid dist-tag can be used to perform a prerelease increment to a semver, without resulting in an invalid version
+          const test = incSemver('1.0.0', 'prerelease', value);
+          if (!isValidSemver(test, {loose: false})) {
+            return `dist-tag can only contain URL-friendly characters`;
+          }
+
+          return true;
+        }),
     },
     {
       name: 'studioV2Support',
@@ -232,15 +304,73 @@ export default {
       fieldset: 'code',
       hidden: ({document}) =>
         document.studioVersion !== 3 || document.studioV2Support !== 'discontinued',
+      validation: (Rule) =>
+        Rule.custom((value, {document}) => {
+          if (document.studioVersion !== 3 || document.studioV2Support !== 'discontinued') {
+            return true;
+          }
+          if (typeof value !== 'string' || !value) {
+            return 'Required';
+          }
+          // Validate the version tag the same npm will when someone attempts using the generated install command in the listing
+          if (!isValidSemver(cleanSemver(value), {loose: false})) {
+            return `Enter a valid semver version`;
+          }
+          const sanitized = cleanSemver(value, {loose: false});
+          if (sanitized !== value) {
+            return client
+              .patch(document._id)
+              .set({v2DistTag: sanitized})
+              .commit()
+              .then(() => {
+                return true;
+              });
+          }
+          return true;
+        }),
     },
     {
       name: 'v2PackageName',
       type: 'string',
-      title: 'NPM Package name for Studio v2',
+      title: 'NPM package name for Studio v2',
       description: `For plugins that will continue to receive features, bugfixes, etc we recommend publishing it under a new NPM package name. This ensures that even really old Studio v2 users can keep using "sanity install" to use your plugin.`,
       fieldset: 'code',
       hidden: ({document}) =>
         document.studioVersion !== 3 || document.studioV2Support !== 'continued',
+      validation: (Rule) =>
+        Rule.custom((value, {document}) => {
+          if (document.studioVersion !== 3 || document.studioV2Support !== 'continued') {
+            return true;
+          }
+          if (typeof value !== 'string' || !value) {
+            return 'Required';
+          }
+          if (value === document.packageName) {
+            return 'You must specify a different NPM package name for Studio v2';
+          }
+          if (isValidSemver(cleanSemver(value), {loose: true})) {
+            return `name can't be a version string`;
+          }
+          if (value.startsWith('https://www.npmjs.com/package/')) {
+            const v2PackageName = value.replace('https://www.npmjs.com/package/', '');
+            const validation = validateNpmPackageName(v2PackageName);
+            if (validation.validForNewPackages) {
+              return client
+                .patch(document._id)
+                .set({v2PackageName})
+                .commit()
+                .then(() => {
+                  return true;
+                });
+            }
+          }
+          const validation = validateNpmPackageName(value);
+          return Array.isArray(validation.errors)
+            ? validation.errors[0]
+            : Array.isArray(validation.warnings)
+            ? validation.warnings[0]
+            : true;
+        }),
     },
     // Hidden fields populated automatically
     {

--- a/schemas/documents/contributions/tool.js
+++ b/schemas/documents/contributions/tool.js
@@ -186,7 +186,7 @@ export default {
             if (installWith.startsWith('sanity install')) {
               const [, , origin, , ...parts] = packageUrl.split('/');
               return `Set the Studio version to "2"${
-                origin === 'www.npmjs.com' && parts.length === 2
+                origin === 'www.npmjs.com' && parts.length >= 1
                   ? ` and set "NPM package name" to "${parts.join('/')}"`
                   : ''
               } instead of manually specifiying "${installWith}"`;
@@ -266,7 +266,7 @@ export default {
           }
           // Validate the version tag the same npm will when someone attempts using the generated install command in the listing
           if (isValidSemver(cleanSemver(value))) {
-            return `Use a dist-tag name, like "studio-v3", instead of a version number"`;
+            return `Use a dist-tag name, like "studio-v3", instead of a version number`;
           }
           // A valid dist-tag can be used to perform a prerelease increment to a semver, without resulting in an invalid version
           const test = incSemver('1.0.0', 'prerelease', value);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3154,6 +3154,13 @@ builtin-status-codes@^3.0.0:
   resolved "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
   integrity sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=
 
+builtins@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/builtins/-/builtins-5.0.1.tgz#87f6db9ab0458be728564fa81d876d8d74552fa9"
+  integrity sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==
+  dependencies:
+    semver "^7.0.0"
+
 bytes@3.1.2:
   version "3.1.2"
   resolved "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz#8b0beeb98605adf1b128fa4386403c009e0221a5"
@@ -5958,6 +5965,13 @@ hosted-git-info@^2.1.4:
   resolved "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz#dffc0bf9a21c02209090f2aa69429e1414daf3f9"
   integrity sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==
 
+hosted-git-info@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-5.0.0.tgz#df7a06678b4ebd722139786303db80fdf302ea56"
+  integrity sha512-rRnjWu0Bxj+nIfUOkz0695C0H6tRrN5iYIzYejb0tDEefe2AekHu/U5Kn9pEie5vsJqpNQU02az7TGSH3qpz4Q==
+  dependencies:
+    lru-cache "^7.5.1"
+
 hsl-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/hsl-regex/-/hsl-regex-1.0.0.tgz#d49330c789ed819e276a4c0d272dffa30b18fe6e"
@@ -7195,6 +7209,11 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
+lru-cache@^7.5.1:
+  version "7.13.1"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-7.13.1.tgz#267a81fbd0881327c46a81c5922606a2cfe336c4"
+  integrity sha512-CHqbAq7NFlW3RSnoWXLJBxCWaZVBrfa9UEHId2M3AW8iEBurbqduNexEUCGc3SHc6iCYXNJCDi903LajSVAEPQ==
+
 make-dir@^2.0.0, make-dir@^2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz#5f0310e18b8be898cc07009295a30ae41e91e6f5"
@@ -7653,6 +7672,16 @@ normalize-package-data@^2.3.2, normalize-package-data@^2.5.0:
     resolve "^1.10.0"
     semver "2 || 3 || 4 || 5"
     validate-npm-package-license "^3.0.1"
+
+normalize-package-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-4.0.0.tgz#1122d5359af21d4cd08718b92b058a658594177c"
+  integrity sha512-m+GL22VXJKkKbw62ZaBBjv8u6IE3UI4Mh5QakIqs3fWiKe0Xyi6L97hakwZK41/LD4R/2ly71Bayx0NLMwLA/g==
+  dependencies:
+    hosted-git-info "^5.0.0"
+    is-core-module "^2.8.1"
+    semver "^7.3.5"
+    validate-npm-package-license "^3.0.4"
 
 normalize-path@^2.1.1:
   version "2.1.1"
@@ -10200,6 +10229,13 @@ semver@^6.0.0, semver@^6.1.1, semver@^6.1.2, semver@^6.2.3, semver@^6.3.0:
   resolved "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
+semver@^7.0.0, semver@^7.3.5, semver@^7.3.7:
+  version "7.3.7"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.7.tgz#12c5b649afdbf9049707796e22a4028814ce523f"
+  integrity sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==
+  dependencies:
+    lru-cache "^6.0.0"
+
 semver@^7.2.1:
   version "7.3.5"
   resolved "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
@@ -11584,13 +11620,20 @@ v8-compile-cache@^2.0.3:
   resolved "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz#2de19618c66dc247dcfb6f99338035d8245a2cee"
   integrity sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==
 
-validate-npm-package-license@^3.0.1:
+validate-npm-package-license@^3.0.1, validate-npm-package-license@^3.0.4:
   version "3.0.4"
   resolved "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz#fc91f6b9c7ba15c857f4cb2c5defeec39d4f410a"
   integrity sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==
   dependencies:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
+
+validate-npm-package-name@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/validate-npm-package-name/-/validate-npm-package-name-4.0.0.tgz#fe8f1c50ac20afdb86f177da85b3600f0ac0d747"
+  integrity sha512-mzR0L8ZDktZjpX4OB46KT+56MAhl4EIazWP/+G/HPGuvfdaqg4YsCdtOm6U9+LOFyYDoh4dpnpxZRB9MQQns5Q==
+  dependencies:
+    builtins "^5.0.0"
 
 value-equal@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
While updating the exchange with v3 listing info and OmniNav filters:
<img width="491" alt="image" src="https://user-images.githubusercontent.com/81981/182262168-562487c5-deb9-41c3-858b-58699229ddb6.png">

I noticed that some of our listings have the wrong data.
[For example](https://www.sanity.io/plugins/asset-source-remove-bg):
![image](https://user-images.githubusercontent.com/81981/182262355-85b201e4-b605-4354-84ea-b17cf1070963.png)
The install command here is supposed to be: 
```shell
npm i https://www.npmjs.com/package/sanity-plugin-asset-source-remove-bg
```

In any case, this PR adds a bunch of validation related to listings that involve installing something in a v2, or v3, Studio. It makes the process more interactive, and guides you if something isn't optimal, and in some cases it even fixes it for you.

## Scenarios

### A Studio v2 package doesn't specify `studioVersion = 2`

The new Exchange plugin filters expects relevant listings to specify `studioVersion` to be either `2` or `3`.
Most v2 listings specify `Installation command` with a string that starts with `sanity install`.
Thus if the prefix is `sanity install` and `studioVersion` is undefined the validation will now show this message:
<img width="674" alt="image" src="https://user-images.githubusercontent.com/81981/182263145-b8ce456c-e21b-4c2a-9c88-10c7eb3528cb.png">

The `Package URL` field can further enrich the message:
<img width="663" alt="image" src="https://user-images.githubusercontent.com/81981/182263242-ce3ebeb6-e578-4a48-a1fc-94e45c5d0e48.png">

I tried to make the `initialValue` property of the `Package URL` schema be a callback that could do this dynamically for you instead of telling you in the validation callback, but it seems like the callback doesn't receive `context.document` like `hidden` and `validation` do, maybe this is a v3 feature and doesn't exist in v2?

And lastly, the `Installation command` section no longer lists `"sanity install media"` as one of the examples.

### NPM package name validation

Required if `studioVersion` is `2` or `3`
<img width="615" alt="image" src="https://user-images.githubusercontent.com/81981/182263918-3f910719-22eb-4dca-bdfd-a4a00493727e.png">


Converts pasted NPM URLs into just the package name for you.

https://user-images.githubusercontent.com/81981/182263975-8c4bb20a-13c4-42bd-acfa-449b836e67d9.mp4

Performs the same name validation as npm does internally, using `validate-npm-package-name`:
<img width="652" alt="image" src="https://user-images.githubusercontent.com/81981/182264106-2226404d-14da-4c51-8258-145ec7a5383e.png">

### A Studio v2 package that offers a test version for v3

Won't allow a version number, as we want our install commands for v3 to stay greenfield while we're in dev-preview.
<img width="682" alt="image" src="https://user-images.githubusercontent.com/81981/182265924-505f6fee-9d5d-4a02-b7f3-2703488c2b1f.png">

Uses the same validation as npm to prevent mistakes like whitespace etc
<img width="623" alt="image" src="https://user-images.githubusercontent.com/81981/182267622-e9ab29dd-b85c-4dd3-bae6-d1f23207d2a2.png">

### A Studio v3 package has discontinued v2 support

We have a real contribution in this state already, [sanity-plugin-asset-source-giphy](https://sanity-bq7m7qiko.sanity.build/plugins/sanity-plugin-asset-source-giphy).

In this state it's now required to provide the last known v2 version if `Studio v2 support` is set to `Discontinued`.
<img width="629" alt="image" src="https://user-images.githubusercontent.com/81981/182268069-05efdd01-0ab0-4ff5-8829-1b833dc47b0c.png">

It's not valid to specify a dist-tag, as we actively discourage that since a dist-tag indicates the version number might change and that the v2 version will live on under the same package name but under a different dist-tag.

<img width="631" alt="image" src="https://user-images.githubusercontent.com/81981/182268233-4bb60ebd-f157-4f58-923c-b216d2c18a24.png">

If someone enters a prefixed version number, like `v1.0.0`, it'll auto fix to `1.0.0`.

### A Studio v3 package has continued v2 support 

It's required to specify the new package name.

<img width="615" alt="image" src="https://user-images.githubusercontent.com/81981/182268483-bb3718a9-b9e8-4676-8620-ed4c01b39594.png">

It doesn't allow using the same package name in the v2 field.

<img width="652" alt="image" src="https://user-images.githubusercontent.com/81981/182268543-fade4641-322c-4265-9594-2059149fd089.png">

And if someone is confused and paste in a version string that's also caught:
<img width="622" alt="image" src="https://user-images.githubusercontent.com/81981/182268602-48b8d2bc-5172-4129-a2e5-5ad11a62c758.png">
