### PR TITLE
Add vercel deploy link as starter options

### DIFF
--- a/schemas/components/Preview.js
+++ b/schemas/components/Preview.js
@@ -13,9 +13,20 @@ const ErrorDisplay = ({message = 'Fill all the required fields before accessing 
   );
 };
 
+const getURL = (displayed) => {
+  switch (displayed.jumpstartStartType) {
+    case 'github':
+      return resolveProductionUrl(displayed);
+    case 'vercel':
+      return displayed.vercelDeployLink;
+    default:
+      return undefined;
+  }
+};
+
 const Preview = ({document, isMobile}) => {
   const displayed = document?.displayed || {};
-  const url = resolveProductionUrl(displayed);
+  let url = getURL(displayed);
 
   if (!url && displayed._type === 'contribution.schema') {
     return (

--- a/schemas/components/Preview.js
+++ b/schemas/components/Preview.js
@@ -14,7 +14,7 @@ const ErrorDisplay = ({message = 'Fill all the required fields before accessing 
 };
 
 const getURL = (displayed) => {
-  switch (displayed.jumpstartStartType) {
+  switch (displayed.deploymentType) {
     case 'sanityCreate':
       return resolveProductionUrl(displayed);
     case 'vercel':

--- a/schemas/components/Preview.js
+++ b/schemas/components/Preview.js
@@ -15,7 +15,7 @@ const ErrorDisplay = ({message = 'Fill all the required fields before accessing 
 
 const getURL = (displayed) => {
   switch (displayed.jumpstartStartType) {
-    case 'github':
+    case 'sanityCreate':
       return resolveProductionUrl(displayed);
     case 'vercel':
       return displayed.vercelDeployLink;

--- a/schemas/documents/contributions/starter.js
+++ b/schemas/documents/contributions/starter.js
@@ -218,7 +218,7 @@ export default {
     {
       title: 'Vercel Deploy Button link',
       name: 'vercelDeployLink',
-      description: 'The Vercel deployment link generated from the deploy button',
+      description: 'The generated Vercel Deploy Button link',
       type: 'string',
       hidden: ({parent}) => parent.deploymentType !== 'vercel',
       validation: (Rule) =>

--- a/schemas/documents/contributions/starter.js
+++ b/schemas/documents/contributions/starter.js
@@ -216,7 +216,7 @@ export default {
       ],
     },
     {
-      title: 'Vercel deploy link',
+      title: 'Vercel Deploy Button link',
       name: 'vercelDeployLink',
       description: 'The Vercel deployment link generated from the deploy button',
       type: 'string',

--- a/schemas/documents/contributions/starter.js
+++ b/schemas/documents/contributions/starter.js
@@ -51,7 +51,7 @@ class EditorMessage extends React.Component {
         </p>
 
         <p>
-          We currently offer two options to deploy your starter: using sanity.io/create and vercel!
+          We currently offer two options to deploy your starter: using sanity.io/create or Vercel!
         </p>
 
         <h2>Deploying on sanity.io/create</h2>
@@ -170,7 +170,7 @@ export default {
       name: 'deploymentType',
       title: 'What deployment option do you want to use?',
       description:
-        'Using the sanity.io/create means that we will generate a deployment page based on the provided repo id. If Vercel is picked, then you will need to generate a deployment url based on their deploy button logic.',
+        'Using the sanity.io/create means that we will generate a deployment page based on the provided repo id. If Vercel is picked, then you will need to generate a Deploy Button link.',
       type: 'string',
       options: {
         layout: 'radio',
@@ -224,7 +224,7 @@ export default {
       validation: (Rule) =>
         Rule.custom((vercelLink, context) => {
           return context.parent.deploymentType === 'vercel' && !vercelLink
-            ? 'You must have a vercel deploy link'
+            ? 'You must have a Vercel Deploy Button link'
             : true;
         }),
     },

--- a/schemas/documents/contributions/starter.js
+++ b/schemas/documents/contributions/starter.js
@@ -147,7 +147,7 @@ export default {
       options: {
         layout: 'radio',
         list: [
-          {title: 'sanity deploy', value: 'github'},
+          {title: 'sanity.io/create', value: 'sanityCreate'},
           {title: 'vercel', value: 'vercel'},
         ],
       },

--- a/schemas/documents/contributions/starter.js
+++ b/schemas/documents/contributions/starter.js
@@ -65,7 +65,7 @@ class EditorMessage extends React.Component {
               <a href="https://vercel.com/docs/deploy-button#generate-your-own" target="_blank">
                 generate your own deploy button
               </a>{' '}
-              documentation to generate the deployment URL based off your github repository.
+              documentation to generate the deployment URL based off your GitHub repository.
             </p>
             <p>
               Once generated, the URL can be copied from the{' '}

--- a/schemas/documents/contributions/starter.js
+++ b/schemas/documents/contributions/starter.js
@@ -181,7 +181,7 @@ export default {
       hidden: ({parent}) => parent.deploymentType !== 'github',
       validation: (Rule) => {
         return Rule.custom((repoId, context) => {
-          return context.parent.deploymentType === 'github'
+          return context.parent.deploymentType === 'sanityCreate'
             ? [
                 // Ensure repo is named correctly
                 Rule.required()

--- a/schemas/documents/contributions/starter.js
+++ b/schemas/documents/contributions/starter.js
@@ -178,7 +178,6 @@ export default {
       description:
         'The repo ID or slug from your starter’s GitHub repository (eg. sanity-io/sanity-template-example)',
       type: 'string',
-      hidden: ({parent}) => parent.deploymentType !== 'sanityCreate',
       validation: (Rule) => {
         return Rule.custom((repoId, context) => {
           return context.parent.deploymentType === 'sanityCreate'
@@ -213,10 +212,12 @@ export default {
       description: 'The Vercel deployment link generated from the deploy button',
       type: 'string',
       hidden: ({parent}) => parent.deploymentType !== 'vercel',
-      validation: (Rule) => [
-        // Ensure repo is named correctly
-        Rule.required(),
-      ],
+      validation: (Rule) =>
+        Rule.custom((vercelLink, context) => {
+          return context.parent.deploymentType === 'vercel' && !vercelLink
+            ? 'You must have a vercel deploy link'
+            : true;
+        }),
     },
     {
       title: '📷 Main image',

--- a/schemas/documents/contributions/starter.js
+++ b/schemas/documents/contributions/starter.js
@@ -40,7 +40,7 @@ class EditorMessage extends React.Component {
 
     const nameValidity = testName(document.repoId);
     const manifestValidity = window._starterValidity;
-    const jumpstartStartType = document.jumpstartStartType;
+    const deploymentType = document.deploymentType;
 
     return (
       <div>
@@ -58,14 +58,14 @@ class EditorMessage extends React.Component {
           documentation.
         </p>
 
-        {jumpstartStartType === 'vercel' && (
+        {deploymentType === 'vercel' && (
           <div>
             <p>
               If you are using Vercel, you can use the{' '}
               <a href="https://vercel.com/docs/deploy-button#generate-your-own" target="_blank">
                 generate your own deploy button
               </a>{' '}
-              documentation to generate the jumpstart URL based off your github repository.
+              documentation to generate the deployment URL based off your github repository.
             </p>
             <p>
               Once generated, the URL can be copied from the{' '}
@@ -83,7 +83,7 @@ class EditorMessage extends React.Component {
           </a>{' '}
           in the main desk menu of this studio.
         </p>
-        {(!nameValidity || manifestValidity === false) && !jumpstartStartType === 'vercel' && (
+        {(!nameValidity || manifestValidity === false) && !deploymentType === 'vercel' && (
           <div>
             <h3>Error(s) we spotted with your starter:</h3>
             <ul>
@@ -141,13 +141,13 @@ export default {
       ],
     },
     {
-      name: 'jumpstartStartType',
-      title: 'What jumpstart option do you want to use?',
+      name: 'deploymentType',
+      title: 'What deployment option do you want to use?',
       type: 'string',
       options: {
         layout: 'radio',
         list: [
-          {title: 'sanity jumpstart', value: 'github'},
+          {title: 'sanity deploy', value: 'github'},
           {title: 'vercel', value: 'vercel'},
         ],
       },
@@ -178,10 +178,10 @@ export default {
       description:
         'The repo ID or slug from your starter’s GitHub repository (eg. sanity-io/sanity-template-example)',
       type: 'string',
-      hidden: ({parent}) => parent.jumpstartStartType !== 'github',
+      hidden: ({parent}) => parent.deploymentType !== 'github',
       validation: (Rule) => {
         return Rule.custom((repoId, context) => {
-          return context.parent.jumpstartStartType === 'github'
+          return context.parent.deploymentType === 'github'
             ? [
                 // Ensure repo is named correctly
                 Rule.required()
@@ -212,7 +212,7 @@ export default {
       name: 'vercelDeployLink',
       description: 'The vercel deployment link generated from the deploy button',
       type: 'string',
-      hidden: ({parent}) => parent.jumpstartStartType !== 'vercel',
+      hidden: ({parent}) => parent.deploymentType !== 'vercel',
       validation: (Rule) => [
         // Ensure repo is named correctly
         Rule.required(),

--- a/schemas/documents/contributions/starter.js
+++ b/schemas/documents/contributions/starter.js
@@ -151,7 +151,7 @@ export default {
           {title: 'Vercel', value: 'vercel'},
         ],
       },
-      initialValue: 'github',
+      initialValue: 'sanityCreate',
     },
     {
       name: 'slug',

--- a/schemas/documents/contributions/starter.js
+++ b/schemas/documents/contributions/starter.js
@@ -187,33 +187,33 @@ export default {
       description:
         'The repo ID or slug from your starter’s GitHub repository (eg. sanity-io/sanity-template-example)',
       type: 'string',
-      validation: (Rule) => {
-        return Rule.custom((repoId, context) => {
-          return context.parent.deploymentType === 'sanityCreate'
-            ? [
-                // Ensure repo is named correctly
-                Rule.required()
-                  .regex(NAME_REGEX)
-                  .error(
-                    'The repository name must start with sanity-template: {owner}/sanity-template-{name}'
-                  ),
-                // Ensure repo is compatible with sanity.io/create
-                Rule.custom(async (repoId) => {
-                  if (!repoId) {
-                    return true;
-                  }
-                  const res = await fetch(`/api/validate-starter?repoId=${repoId}`);
-                  if (res.status === 200) {
-                    window._starterValidity = true;
-                    return true;
-                  }
-                  window._starterValidity = false;
-                  return "Sanity.io/create couldn't validate your template.";
-                }),
-              ]
-            : true;
-        });
-      },
+      validation: (Rule) => [
+        // Ensure that the repo id field
+        Rule.custom(async (repoId, context) => {
+          if (!repoId && context.parent.deploymentType === 'sanityCreate') {
+            return 'You must have a repo id';
+          }
+        }),
+
+        // Ensure repo is named correctly
+        Rule.regex(NAME_REGEX).error(
+          'The repository name must start with sanity-template: {owner}/sanity-template-{name}'
+        ),
+
+        // Ensure repo is compatible with sanity.io/create
+        Rule.custom(async (repoId, context) => {
+          if (!repoId || context.parent.deploymentType === 'sanityCreate') {
+            return true;
+          }
+          const res = await fetch(`/api/validate-starter?repoId=${repoId}`);
+          if (res.status === 200) {
+            window._starterValidity = true;
+            return true;
+          }
+          window._starterValidity = false;
+          return "Sanity.io/create couldn't validate your template.";
+        }),
+      ],
     },
     {
       title: 'Vercel deploy link',

--- a/schemas/documents/contributions/starter.js
+++ b/schemas/documents/contributions/starter.js
@@ -178,7 +178,7 @@ export default {
       description:
         'The repo ID or slug from your starter’s GitHub repository (eg. sanity-io/sanity-template-example)',
       type: 'string',
-      hidden: ({parent}) => parent.deploymentType !== 'github',
+      hidden: ({parent}) => parent.deploymentType !== 'sanityCreate',
       validation: (Rule) => {
         return Rule.custom((repoId, context) => {
           return context.parent.deploymentType === 'sanityCreate'

--- a/schemas/documents/contributions/starter.js
+++ b/schemas/documents/contributions/starter.js
@@ -210,7 +210,7 @@ export default {
     {
       title: 'Vercel deploy link',
       name: 'vercelDeployLink',
-      description: 'The vercel deployment link generated from the deploy button',
+      description: 'The Vercel deployment link generated from the deploy button',
       type: 'string',
       hidden: ({parent}) => parent.deploymentType !== 'vercel',
       validation: (Rule) => [

--- a/schemas/documents/contributions/starter.js
+++ b/schemas/documents/contributions/starter.js
@@ -49,6 +49,13 @@ class EditorMessage extends React.Component {
           We're thrilled to have your contribution - we are sure it'll help many people to get
           started quickly!
         </p>
+
+        <p>
+          We currently offer two options to deploy your starter: using sanity.io/create and vercel!
+        </p>
+
+        <h2>Deploying on sanity.io/create</h2>
+
         <p>
           In order to have your started listed in Sanity.io, however, we need it to follow a the
           steps outlined in the{' '}
@@ -57,24 +64,6 @@ class EditorMessage extends React.Component {
           </a>{' '}
           documentation.
         </p>
-
-        {deploymentType === 'vercel' && (
-          <div>
-            <p>
-              If you are using Vercel, you can use the{' '}
-              <a href="https://vercel.com/docs/deploy-button#generate-your-own" target="_blank">
-                generate your own deploy button
-              </a>{' '}
-              documentation to generate the deployment URL based off your GitHub repository.
-            </p>
-            <p>
-              Once generated, the URL can be copied from the{' '}
-              <a href="https://vercel.com/docs/deploy-button#snippets">
-                Snippets section (if the URL option is picked)
-              </a>
-            </p>
-          </div>
-        )}
         <p>
           If your contribution cannot meet these guidelines, that's OK! You can add it as a showcase
           project by clicking on the{' '}
@@ -83,6 +72,7 @@ class EditorMessage extends React.Component {
           </a>{' '}
           in the main desk menu of this studio.
         </p>
+
         {(!nameValidity || manifestValidity === false) && !deploymentType === 'vercel' && (
           <div>
             <h3>Error(s) we spotted with your starter:</h3>
@@ -111,6 +101,23 @@ class EditorMessage extends React.Component {
             </ul>
           </div>
         )}
+
+        <h2>Deploying with Vercel Deploy Button</h2>
+        <div>
+          <p>
+            If you are using Vercel, you can use the{' '}
+            <a href="https://vercel.com/docs/deploy-button#generate-your-own" target="_blank">
+              generate your own deploy button
+            </a>{' '}
+            documentation to generate the deployment URL based off your GitHub repository.
+          </p>
+          <p>
+            Once generated, the URL can be copied from the{' '}
+            <a href="https://vercel.com/docs/deploy-button#snippets">
+              Snippets section (by picking the URL tab)
+            </a>
+          </p>
+        </div>
       </div>
     );
   }
@@ -141,19 +148,6 @@ export default {
       ],
     },
     {
-      name: 'deploymentType',
-      title: 'What deployment option do you want to use?',
-      type: 'string',
-      options: {
-        layout: 'radio',
-        list: [
-          {title: 'sanity.io/create', value: 'sanityCreate'},
-          {title: 'Vercel', value: 'vercel'},
-        ],
-      },
-      initialValue: 'sanityCreate',
-    },
-    {
       name: 'slug',
       type: 'slug',
       title: 'Relative address in the community site',
@@ -171,6 +165,21 @@ export default {
       type: 'string',
       readOnly: true,
       inputComponent: withDocument(EditorMessage),
+    },
+    {
+      name: 'deploymentType',
+      title: 'What deployment option do you want to use?',
+      description:
+        'Using the sanity.io/create means that we will generate a deployment page based on the provided repo id. If Vercel is picked, then you will need to generate a deployment url based on their deploy button logic.',
+      type: 'string',
+      options: {
+        layout: 'radio',
+        list: [
+          {title: 'sanity.io/create', value: 'sanityCreate'},
+          {title: 'Vercel', value: 'vercel'},
+        ],
+      },
+      initialValue: 'sanityCreate',
     },
     {
       title: 'Github repository ID',

--- a/schemas/documents/contributions/starter.js
+++ b/schemas/documents/contributions/starter.js
@@ -148,7 +148,7 @@ export default {
         layout: 'radio',
         list: [
           {title: 'sanity.io/create', value: 'sanityCreate'},
-          {title: 'vercel', value: 'vercel'},
+          {title: 'Vercel', value: 'vercel'},
         ],
       },
       initialValue: 'github',


### PR DESCRIPTION
Hi 👋 

This is a very small step towards a bigger initiative to add different deploy options within the exchange. Right now, the studio only uses the sanity jumpstart logic, with the changes in this PR we've added an option to use the vercel deployment links. 

Here is the expected behavior:

https://user-images.githubusercontent.com/6951139/190617310-21c09cf5-10ef-44e3-8f95-9237613593eb.mov

(not in this pr, but for illustration of the "end" of the flow)

https://user-images.githubusercontent.com/6951139/190617433-5ff7fb10-741a-4271-a6cb-8458edf4b141.mov


