### PR TITLE
Add vercel deploy link as starter options (#92)

### DIFF
--- a/schemas/components/Preview.js
+++ b/schemas/components/Preview.js
@@ -13,9 +13,20 @@ const ErrorDisplay = ({message = 'Fill all the required fields before accessing 
   );
 };
 
+const getURL = (displayed) => {
+  switch (displayed.deploymentType) {
+    case 'sanityCreate':
+      return resolveProductionUrl(displayed);
+    case 'vercel':
+      return displayed.vercelDeployLink;
+    default:
+      return undefined;
+  }
+};
+
 const Preview = ({document, isMobile}) => {
   const displayed = document?.displayed || {};
-  const url = resolveProductionUrl(displayed);
+  let url = getURL(displayed);
 
   if (!url && displayed._type === 'contribution.schema') {
     return (


### PR DESCRIPTION
Tried to release it on my terminal but got a few rebase errors so I feel it's just safer to do it through here

* feat: add vercel jumpstart type

* fix: add preview for vercel jumpstart

* refactor: change jumpstart to deploy

* refactor: capitalise vercel

* refactor: Update sanity jumpstart name schemas/documents/contributions/starter.js

Co-authored-by: Fred Carlsen <fred@sjelfull.no>

* refactor: Update sanity jumpstart name schemas/documents/contributions/starter.js

Co-authored-by: Fred Carlsen <fred@sjelfull.no>

* refactor: capitalise github schemas/documents/contributions/starter.js

Co-authored-by: Fred Carlsen <fred@sjelfull.no>

* refactor: capitalise Vercel

Co-authored-by: Fred Carlsen <fred@sjelfull.no>

* refactor: change version from github to sanitycreate

Co-authored-by: Fred Carlsen <fred@sjelfull.no>

* refactor: change version from github to sanitycreate

Co-authored-by: Fred Carlsen <fred@sjelfull.no>

* refactor: change version from github to sanitycreate

Co-authored-by: Fred Carlsen <fred@sjelfull.no>

* refactor: have repoid always available

* refactor: update order for doc

* refactor: fix issues with validation

* refactor: switch jumpstartstarttype to deploymenttype

Co-authored-by: Fred Carlsen <fred@sjelfull.no>

* refactor: update title

Co-authored-by: Fred Carlsen <fred@sjelfull.no>

* refactor: update casing & copy

Co-authored-by: Fred Carlsen <fred@sjelfull.no>

* Apply suggestions from code review

Co-authored-by: Fred Carlsen <fred@sjelfull.no>