### PR TITLE
feat: add studio version to starters schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "description": "Sanity Community Studio and Slack Bot",
   "main": "package.json",
   "author": "Knut Melvær <knut@sanity.io>",
+  "engines": {
+    "node": ">=12.0.0"
+  },
   "license": "MIT",
   "scripts": {
     "_dev": "ts-node-dev src/dev.ts --respawn --transpileOnly",

--- a/schemas/documents/contributions/starter.js
+++ b/schemas/documents/contributions/starter.js
@@ -148,6 +148,22 @@ export default {
       ],
     },
     {
+      name: 'studioVersion',
+      title: 'Studio version',
+      type: 'number',
+      description: 'What Sanity Studio version was this starter was built for.',
+      initialValue: -1,
+      options: {
+        layout: 'radio',
+        direction: 'horizontal',
+        list: [
+          {value: -1, title: 'N/A'},
+          {value: 2, title: 'Studio v2'},
+          {value: 3, title: 'Studio v3'},
+        ],
+      },
+    },
+    {
       name: 'slug',
       type: 'slug',
       title: 'Relative address in the community site',


### PR DESCRIPTION
Allow support for adding the v3 Ready label to starters in exchange

related: [www-sanity-io pr here](https://github.com/sanity-io/www-sanity-io/pull/1029)