### PR TITLE
fix: remove validation for optional guides illustration field

### DIFF
--- a/schemas/documents/globalSettings.js
+++ b/schemas/documents/globalSettings.js
@@ -34,7 +34,6 @@ export default {
       name: 'guidesConversionIllustration',
       title: "Illustration for guides' conversion script",
       type: 'image',
-      validation: (Rule) => Rule.required(),
     },
     {
       name: 'menuIntegrations',


### PR DESCRIPTION
`guidesConversionIllustration` is treated as an optional field in the Exchange front-end, and should there not have a validation rule.