### PR TITLE
feat: add public field to tags

### DIFF
--- a/schemas/documents/tag.js
+++ b/schemas/documents/tag.js
@@ -22,6 +22,13 @@ export default {
       },
     },
     {
+      name: 'public',
+      type: 'boolean',
+      title: 'Show on answers page',
+      description: 'Whether this tag should be listed with tickets on the answers page',
+      initialValue: false,
+    },
+    {
       name: 'alternatives',
       title: 'Alternative titles',
       type: 'array',


### PR DESCRIPTION
## Intent

[See ticket](https://linear.app/sanity/issue/GRO-32/fix-tags-filter-on-answers-page)

Allow editors to choose which tags appear on the [answers page](https://www.sanity.io/answers)

## Description

Adds a n optional `public` boolean field to tags so that editors can inform the marketing website which tags to display with tickets on the answers page. Tags will not "not public" by default and having them appear publicly is opt-in