### PR TITLE
feat: Add ambassadors document

### DIFF
--- a/parts/adminStructure.js
+++ b/parts/adminStructure.js
@@ -478,6 +478,7 @@ const getAdminStructure = () => [
                 .filter('_type == $type')
                 .params({type: 'person'})
             ),
+          S.documentListItem().id('communityAmbassadors').schemaType('communityAmbassadors'),
           S.documentListItem().id('studioTutorials').schemaType('studioTutorials'),
           S.documentListItem().id('communityBulletin').schemaType('communityBulletin'),
           S.documentListItem().id('landing.getStarted').schemaType('landing.getStarted'),

--- a/sanity.json
+++ b/sanity.json
@@ -5,7 +5,7 @@
   },
   "api": {
     "projectId": "81pocpw8",
-    "dataset": "production"
+    "dataset": "gro-62-community-ambassadors"
   },
   "plugins": [
     "@sanity/base",

--- a/sanity.json
+++ b/sanity.json
@@ -5,7 +5,7 @@
   },
   "api": {
     "projectId": "81pocpw8",
-    "dataset": "gro-62-community-ambassadors"
+    "dataset": "production"
   },
   "plugins": [
     "@sanity/base",

--- a/schemas/documents/communityAmbassadors.js
+++ b/schemas/documents/communityAmbassadors.js
@@ -1,0 +1,30 @@
+import React from "react"
+import Icon from "../components/icon"
+
+export default {
+  name: 'communityAmbassadors',
+  title: 'Community Ambassador',
+  icon: () => <Icon emoji="🥇" />,
+  type: 'document',
+  fields: [
+    {
+      name: 'chosenPersons',
+      title: 'Persons to highlight as Community Ambassadors in the community pages',
+      description: 'The order isn\'t relevant currently',
+      type: 'array',
+      of: [
+        {
+          type: 'reference',
+          to: [{type: 'person'}],
+        }
+      ]
+    }
+  ],
+  preview: {
+    prepare() {
+      return {
+        title: "Community ambassadors"
+      }
+    }
+  }
+}

--- a/schemas/documents/communityAmbassadors.js
+++ b/schemas/documents/communityAmbassadors.js
@@ -8,7 +8,7 @@ export default {
   type: 'document',
   fields: [
     {
-      name: 'chosenPersons',
+      name: 'persons',
       title: 'Persons to highlight as Community Ambassadors in the community pages',
       description: 'The order isn\'t relevant currently',
       type: 'array',

--- a/schemas/schema.js
+++ b/schemas/schema.js
@@ -25,6 +25,7 @@ import studioImage from './objects/studioImage';
 import simpleBlockContent from './objects/simpleBlockContent';
 import contributions from './documents/contributions';
 import curatedContribution from './documents/contributions/curatedContribution';
+import communityAmbassadors from './documents/communityAmbassadors';
 import studioTutorials from './documents/studioTutorials';
 import guideBody from './objects/guideBody';
 import communityBulletin from './documents/communityBulletin';
@@ -52,6 +53,7 @@ export default createSchema({
     ticket,
     studioTutorials,
     communityBulletin,
+    communityAmbassadors,
     globalSettings,
     ...contributions,
     curatedContribution,


### PR DESCRIPTION
## Intent

Linear task: https://linear.app/sanity/issue/GRO-62/highlight-community-ambassadors-on-exchange

Implements a "Community ambassadors" document that allows the adding of individual community members, which is used in the website to highlight them with badges and sort them first in lists.

## Description

(click on picture to play the gif; doesn't always play on github automatically)

![ambassador_badge_implementation](https://user-images.githubusercontent.com/232730/214562758-366f9bb1-ed4b-446b-a370-8659a1bfec1f.gif)

## Testing this PR

1. Open [community studio preview build](https://hjaelp-community-studio-dtj4cy4mp.sanity.build/desk/communityEcosystem;communityAmbassadors)
2. Add or remove persons from the list of ambassadors, and publish document (**note: it might take a minute or two for changes to be reflected in the next step)**
3. Open [sanity community page preview build](https://sanity-im0py8flj.sanity.build/exchange/community)
4. Observe that the persons in the community studio added to the list of persons in the Community ecosystem -> Community ambassadors document are shown first in the list of community members, with a badge next to their name
5. Click on an ambassador member to observe the badge on the profile page
