### PR TITLE
Add support for different deployment types

### DIFF
--- a/schemas/documents/contributions/starter.js
+++ b/schemas/documents/contributions/starter.js
@@ -100,7 +100,7 @@ export default {
           {title: 'None', value: 'none'},
         ],
       },
-      initialValue: 'sanityCreate',
+      initialValue: 'none',
     },
     {
       title: 'Netlify Deploy Button link',

--- a/schemas/documents/contributions/starter.js
+++ b/schemas/documents/contributions/starter.js
@@ -90,18 +90,39 @@ export default {
     {
       name: 'deploymentType',
       title: 'What deployment option do you want to use?',
-      description:
-        'Using the sanity.io/create means that we will generate a deployment page based on the provided repo id. If Vercel is picked, then you will need to generate a Deploy Button link.',
+      description: 'Choose the deployment type for this project',
       type: 'string',
-      hidden: ({parent}) => parent.studioVersion === 3,
       options: {
         layout: 'radio',
         list: [
-          {title: 'sanity.io/create', value: 'sanityCreate'},
           {title: 'Vercel', value: 'vercel'},
+          {title: 'Netlify', value: 'netlify'},
+          {title: 'None', value: 'none'},
         ],
       },
       initialValue: 'sanityCreate',
+    },
+    {
+      title: 'Netlify Deploy Button link',
+      name: 'netlifyDeployLink',
+      description: 'The Netlify Deploy Button link',
+      type: 'string',
+      hidden: ({parent}) => parent.deploymentType !== 'netlify',
+      validation: (Rule) =>
+        Rule.custom((netlifyLink, context) => {
+          return context.parent.deploymentType === 'netlify' && !netlifyLink ? 'Required' : true;
+        }),
+    },
+    {
+      title: 'Vercel Deploy Button link',
+      name: 'vercelDeployLink',
+      description: 'The Vercel Deploy Button link',
+      type: 'string',
+      hidden: ({parent}) => parent.deploymentType !== 'vercel',
+      validation: (Rule) =>
+        Rule.custom((vercelLink, context) => {
+          return context.parent.deploymentType === 'vercel' && !vercelLink ? 'Required' : true;
+        }),
     },
     {
       title: 'Repository URL',
@@ -172,21 +193,6 @@ export default {
           }
 
           return true;
-        }),
-    },
-    {
-      title: 'Vercel Deploy Button link',
-      name: 'vercelDeployLink',
-      description: 'The generated Vercel Deploy Button link',
-      type: 'string',
-      hidden: ({parent}) => parent.deploymentType !== 'vercel',
-      validation: (Rule) =>
-        Rule.custom((vercelLink, context) => {
-          return context.parent.deploymentType === 'vercel' &&
-            !vercelLink &&
-            context.parent.studioVersion === 2
-            ? 'Required'
-            : true;
         }),
     },
     {


### PR DESCRIPTION
Added the option to choose deployment type from Vercel, Netlify and "none" on contributions articles. As we expand support for different deployment types, we'll have to manually add them unless we add an "other" value that lets you specify a custom title and URL for the button.

<img width="371" alt="image" src="https://user-images.githubusercontent.com/16625915/225311961-e403311a-5761-4ed6-b33d-221b60ef0a82.png">

<img width="374" alt="image" src="https://user-images.githubusercontent.com/16625915/225311792-22b32ef7-5368-448b-a613-8034c9aaa0cb.png">
