### PR TITLE
feat: always show CTA at the bottom of guides

### DIFF
--- a/schemas/documents/contributions/guide.js
+++ b/schemas/documents/contributions/guide.js
@@ -242,33 +242,5 @@ export default {
         description: 'Add any Sanity tools & plugins you use, mention or reccommend in this guide.',
       },
     }),
-    {
-      name: 'conversionScript',
-      title: 'CTA type at the bottom of the article',
-      description:
-        '❓ Optional. Exists to encourage readers to try out Sanity when they\'re done reading the article. Defaults to "None".',
-      type: 'string',
-      options: {
-        list: [
-          {
-            value: 'none',
-            title: 'None',
-          },
-          {
-            value: 'textOnly',
-            title: 'Text-only',
-          },
-          {
-            value: 'textIllustration',
-            title: 'Text w/ illustration',
-          },
-          {
-            value: 'siteControlled',
-            title: 'Allow site to determine UI',
-          },
-        ],
-        layout: 'radio',
-      },
-    },
   ],
 };

--- a/schemas/documents/globalSettings.js
+++ b/schemas/documents/globalSettings.js
@@ -31,11 +31,6 @@ export default {
       title: 'Conversion script for guides',
     },
     {
-      name: 'guidesConversionIllustration',
-      title: "Illustration for guides' conversion script",
-      type: 'image',
-    },
-    {
       name: 'menuIntegrations',
       title: 'Integrations in the global nav',
       type: 'array',


### PR DESCRIPTION
Fixes [GRO-470](https://linear.app/sanity/issue/GRO-470)

Remove option to show or hide CTA at the bottom of guides.

There is a [corresponding PR in www-sanity.io](https://github.com/sanity-io/www-sanity-io/pull/1344).