### PR TITLE
Add answer feedback

### DIFF
--- a/parts/adminStructure.js
+++ b/parts/adminStructure.js
@@ -11,6 +11,7 @@ import RecentTicketsIcon from '../schemas/components/icon/recentTicketsIcon';
 import ThreadPreview from '../schemas/components/threadPreview';
 import curationStructure from './curationStructure';
 import feedbackStructure from './feedbackStructure';
+import answerFeedbackStructure from './answerFeedbackStructure';
 import getSupportStructure from './supportStructure';
 
 const LiveIcon = ({off}) => (
@@ -430,6 +431,7 @@ const getAdminStructure = () => [
                 .items(CONTRIBUTION_TYPES.map((type) => S.documentTypeListItem(type)))
             ),
           feedbackStructure,
+          answerFeedbackStructure,
           S.listItem()
             .title('Contributions migrated from admin (needs review)')
             .icon(() => <Icon emoji="🚨" />)

--- a/parts/answerFeedbackStructure.js
+++ b/parts/answerFeedbackStructure.js
@@ -1,0 +1,63 @@
+import S from '@sanity/desk-tool/structure-builder';
+import {ratings} from '../schemas/documents/answerFeedback';
+// import { MdFeedback, MdInbox, MdCheckCircle, MdStarBorder, Fi } from 'react-icons/md'
+
+export default S.listItem()
+  .title('Answer feedback')
+  // .icon(MdFeedback)
+  .child(
+    S.list()
+      .title('Answer feedback')
+      .items([
+        S.documentTypeListItem('answerFeedback').title('All feedback'),
+        // .icon(MdFeedback)
+        S.listItem()
+          // .icon(MdInbox)
+          .title('Inbox')
+          .id('answer-feedback-inbox')
+          .child(
+            S.documentList()
+              .title('Inbox')
+              .menuItems(S.orderingMenuItemsForType('answerFeedback'))
+              .schemaType('answerFeedback')
+              .filter(
+                '_type == "answerFeedback" && defined(comment) && (!defined(done) || done == false)'
+              )
+          ),
+        S.listItem()
+          // .icon(MdCheckCircle)
+          .title('Done')
+          .id('answer-feedback-by-done')
+          .child(
+            S.documentList()
+              .title('Done')
+              .menuItems(S.orderingMenuItemsForType('answerFeedback'))
+              .schemaType('answerFeedback')
+              .filter('_type == "answerFeedback" && done == true')
+          ),
+        S.listItem()
+          // .icon(MdStarBorder)
+          .title('Feedback by rating')
+          .id('answer-feedback-by-rating')
+          .child(
+            S.list()
+              .title('Ratings')
+              .items(
+                Object.keys(ratings).map((rating) =>
+                  S.listItem()
+                    .title(ratings[rating])
+                    .id(`rating-list-${rating}`)
+                    .child(
+                      S.documentList()
+                        .title(rating)
+                        .menuItems(S.orderingMenuItemsForType('answerFeedback'))
+                        .filter(
+                          `_type == 'answerFeedback' && rating == $rating && defined(comment)`
+                        )
+                        .params({rating: parseInt(rating, 10)})
+                    )
+                )
+              )
+          ),
+      ])
+  );

--- a/parts/supportStructure.js
+++ b/parts/supportStructure.js
@@ -2,10 +2,10 @@ import React from 'react';
 import S from '@sanity/desk-tool/structure-builder';
 import userStore from 'part:@sanity/base/user';
 import sanityClient from 'part:@sanity/base/client';
-import {EnvelopeIcon} from '@sanity/icons';
-import {formatISO, subHours} from 'date-fns';
+import { EnvelopeIcon } from '@sanity/icons';
+import { formatISO, subHours } from 'date-fns';
 import documentStore from 'part:@sanity/base/datastore/document';
-import {map} from 'rxjs/operators';
+import { map } from 'rxjs/operators';
 import {
   ActivityIcon,
   UserIcon,
@@ -16,7 +16,7 @@ import {
   TagIcon,
 } from '@sanity/icons';
 
-const client = sanityClient.withConfig({apiVersion: '2022-10-31'});
+const client = sanityClient.withConfig({ apiVersion: '2022-10-31' });
 
 const weekThreshold = formatISO(subHours(new Date(), 168));
 
@@ -35,7 +35,7 @@ const getSupportStructure = () =>
               S.documentList()
                 .title('New Tickets')
                 .filter(`_type == 'ticket' && _createdAt > $weekThreshold`)
-                .params({weekThreshold})
+                .params({ weekThreshold })
             ),
           S.listItem()
             .title('Recently Resolved')
@@ -44,7 +44,7 @@ const getSupportStructure = () =>
               S.documentList()
                 .title('Recently Resolved')
                 .filter(`_type == 'ticket' && _createdAt > $weekThreshold && status == 'resolved'`)
-                .params({weekThreshold})
+                .params({ weekThreshold })
             ),
           S.listItem()
             .title('Tickets by Tag')
@@ -52,12 +52,12 @@ const getSupportStructure = () =>
             .child(
               S.documentTypeList('tag')
                 .title('Tickets by Tag')
-                .defaultOrdering([{field: 'title', direction: 'asc'}])
+                .defaultOrdering([{ field: 'title', direction: 'asc' }])
                 .child((tagId) =>
                   S.documentList()
                     .title('Tickets')
                     .filter(`_type == 'ticket' && $tagId in tags[]._ref`)
-                    .params({tagId})
+                    .params({ tagId })
                 )
             ),
           S.listItem()
@@ -66,7 +66,7 @@ const getSupportStructure = () =>
             .child(
               S.documentList()
                 .title('Published on Exchange')
-                .filter(`_type == 'ticket' && status == 'resolved' && defined(slug.current)`)
+                .filter(`_type == 'editorial' && defined(slug.current)`)
             ),
           S.divider(),
           S.listItem()

--- a/schemas/documents/answerFeedback.js
+++ b/schemas/documents/answerFeedback.js
@@ -53,8 +53,7 @@ export default {
       name: 'answer',
       type: 'reference',
       weak: true,
-      // TODO(esseb): Should this be `editorial` instead?
-      to: {type: 'ticket'},
+      to: {type: 'editorial'},
     },
     {
       title: 'Comment',

--- a/schemas/documents/answerFeedback.js
+++ b/schemas/documents/answerFeedback.js
@@ -1,0 +1,77 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export const ratings = {
+  '-1': '🙁',
+  0: '🙂',
+  1: '🤩',
+};
+
+const RatingPreview = React.forwardRef(({value}, ref) => {
+  return (
+    <div ref={ref} style={{fontSize: '4em'}}>
+      {ratings[value]}
+    </div>
+  );
+});
+
+RatingPreview.displayName = 'RatingPreview';
+RatingPreview.propTypes = {
+  value: PropTypes.string.isRequired,
+};
+
+export default {
+  title: 'Answer feedback',
+  name: 'answerFeedback',
+  type: 'document',
+  preview: {
+    select: {
+      title: 'comment',
+      answerTitle: 'answer.editorialTitle',
+      rating: 'rating',
+      _createdAt: '_createdAt',
+    },
+    prepare(selection) {
+      const {title = '[No comment]', rating, answerTitle, _createdAt} = selection;
+
+      return {
+        title,
+        subtitle: `${answerTitle} - ${new Date(_createdAt).toLocaleString()}`,
+        media: <h1>{ratings[rating]}</h1>,
+      };
+    },
+  },
+  fields: [
+    {
+      title: 'Rating',
+      name: 'rating',
+      type: 'number',
+      inputComponent: RatingPreview,
+    },
+    {
+      title: 'Answer',
+      name: 'answer',
+      type: 'reference',
+      weak: true,
+      // TODO(esseb): Should this be `editorial` instead?
+      to: {type: 'ticket'},
+    },
+    {
+      title: 'Comment',
+      name: 'comment',
+      type: 'text',
+      description: 'Comment submitted from sanity.io',
+    },
+    {
+      name: 'done',
+      type: 'boolean',
+      title: 'Is this feedback dealt with?',
+    },
+    {
+      name: 'notes',
+      type: 'text',
+      title: 'Internal notes',
+      description: 'What did we do with this feedback?',
+    },
+  ],
+};

--- a/schemas/documents/editorial.js
+++ b/schemas/documents/editorial.js
@@ -1,0 +1,223 @@
+import React from 'react';
+import Icon from '../components/icon';
+import OpenInSlack from '../components/openInSlack';
+import actions from '../inputs/actions';
+import { getContributionTaxonomies } from './contributions/contributionUtils';
+import PathInput from '../components/PathInput';
+
+const LiveIcon = () => (
+  <svg
+    width="12px"
+    viewBox="0 0 96 72"
+    version="1.1"
+    xmlns="http://www.w3.org/2000/svg"
+    style={{
+      backgroundColor: '#2276fc',
+      borderRadius: '8px',
+      padding: '2px',
+      position: 'absolute',
+      top: '0',
+      right: '0',
+      height: '12px',
+    }}
+  >
+    <g stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
+      <g fill="#FFFFFF" fillRule="nonzero">
+        <path
+          d="M81.6,2.4 C79.5,0.3 76,0.3 73.8,2.4 C71.7,4.5 71.7,8 73.8,10.2 C80.7,17.1 84.5,26.3 84.5,36 C84.5,45.7 80.7,54.9 73.8,61.8 C71.7,63.9 71.7,67.4 73.8,69.6 C74.9,70.7 76.3,71.2 77.7,71.2 C79.1,71.2 80.5,70.7 81.6,69.6 C90.6,60.6 95.5,48.7 95.5,36.1 C95.5,23.3 90.6,11.4 81.6,2.4 Z"
+          id="Path"
+        ></path>
+        <path
+          d="M11.5,36 C11.5,26.2 15.3,17.1 22.2,10.2 C24.3,8.1 24.3,4.6 22.2,2.4 C20.1,0.3 16.6,0.3 14.4,2.4 C5.4,11.4 0.5,23.3 0.5,36 C0.5,48.6 5.6,60.8 14.5,69.6 C15.6,70.7 17,71.2 18.4,71.2 C19.8,71.2 21.2,70.7 22.3,69.6 C24.4,67.4 24.4,64 22.2,61.8 C15.4,55.1 11.5,45.7 11.5,36 Z"
+          id="Path"
+        ></path>
+        <path
+          d="M67.8,16.3 C65.7,14.1 62.2,14.1 60,16.2 C57.8,18.3 57.8,21.8 59.9,24 C63.1,27.2 64.9,31.5 64.9,36 C64.9,40.5 63.1,44.8 59.9,48 C57.8,50.2 57.8,53.6 60,55.8 C61.1,56.9 62.5,57.4 63.9,57.4 C65.3,57.4 66.7,56.9 67.8,55.8 C73.1,50.5 76,43.5 76,36 C76,28.6 73.1,21.6 67.8,16.3 Z"
+          id="Path"
+        ></path>
+        <path
+          d="M36,16.2 C33.9,14.1 30.4,14.1 28.2,16.2 C22.9,21.5 20,28.6 20,36 C20,43.5 22.9,50.5 28.2,55.8 C29.3,56.9 30.7,57.4 32.1,57.4 C33.5,57.4 34.9,56.9 36,55.8 C38.1,53.7 38.1,50.2 36,48 C32.8,44.8 31,40.5 31,36 C31,31.5 32.8,27.2 36,24 C38.2,21.9 38.2,18.4 36,16.2 Z"
+          id="Path"
+        ></path>
+        <circle id="Oval" cx="48" cy="36" r="8.4"></circle>
+      </g>
+    </g>
+  </svg>
+);
+
+export default {
+  type: 'document',
+  name: 'editorial',
+  title: 'Editorial',
+  icon: () => <Icon emoji="🎫" />,
+  fields: [
+    {
+      name: 'ticket',
+      type: 'reference',
+      to: [{ type: 'ticket' }],
+      readOnly: true,
+      weak: true
+    },
+    {
+      name: 'permalink',
+      title: 'Permalink',
+      type: 'url',
+      readOnly: true,
+      inputComponent: OpenInSlack,
+    },
+    {
+      name: 'relevancy',
+      title: 'How relevant is this ticket for the sanity.io website?',
+      description:
+        'Will people extract value from finding this answer in Google and in the website today, tomorrow and a year from now?',
+      type: 'number',
+      options: {
+        list: [
+          { value: 0, title: "Won't help future users (don't index)" },
+          { value: 25, title: 'Helps with edge cases (findable through Google)' },
+          { value: 50, title: 'Answers a common problem (visible in the UI)' },
+          { value: 100, title: 'Vital answer (highlighted in search and UI)' },
+        ],
+        layout: 'radio',
+      },
+    },
+    {
+      name: 'editorialTitle',
+      title: 'Title to show up in the sanity.io site (if relevant)',
+      description:
+        "⚡ Optional but highly encouraged. We'll fallback to summary, but you can use this to make the question more surfaceable and search-ready.",
+      type: 'text',
+      rows: 1,
+    },
+    {
+      name: 'featured',
+      title: 'Is this thread featured?',
+      type: 'boolean',
+    },
+    ...getContributionTaxonomies(undefined, {
+      solutions: {
+        title: 'Related solutions',
+      },
+      frameworks: {
+        title: 'Related frameworks',
+      },
+      integrations: {
+        title: 'Related integrations/services',
+      },
+      tools: {
+        title: 'Related community tools & plugins',
+      },
+    }).map((field) => ({ ...field })),
+    {
+      name: 'slug',
+      title: '📬 relative address in the community site',
+      description:
+        "💡 avoid special characters, spaces and uppercase letters. This will be auto-generated in the publish action, so you only need to edit it if you're doing it for SEO and easier shareability.",
+      type: 'slug',
+      inputComponent: PathInput,
+      options: {
+        basePath: 'sanity.io/tickets',
+        source: 'title',
+        isUnique: () => true,
+      },
+      // This is auto-generated in the publish action, but authors can overwrite it
+      // hidden: true,
+    },
+    {
+      title: 'Summary',
+      type: 'text',
+      name: 'summary',
+      rows: 5,
+      description: 'An short description of what the question actually is about.',
+    },
+    {
+      title: 'Next action',
+      type: 'string',
+      name: 'action',
+      options: {
+        list: actions,
+        layout: 'radio',
+        direction: 'horizontal',
+      },
+    },
+    {
+      name: 'solvedWith',
+      type: 'object',
+      title: 'Solved with…',
+      description: 'How did we solve this issue? (Optional)',
+      fields: [
+        {
+          name: 'url',
+          type: 'url',
+          title: 'URL',
+          description: 'URL to documentation page, GitHub, demo, etc.',
+        },
+        {
+          name: 'summary',
+          type: 'text',
+          title: 'Summary',
+          rows: 5,
+          description: 'Write a short summary if you want to elaborate more.',
+        },
+      ],
+    },
+  ],
+  initialValue: {
+    status: 'open',
+    action: 'none',
+  },
+  preview: {
+    select: {
+      channelName: 'ticket.channelName',
+      status: 'ticket.status',
+      summary: 'summary',
+      tags0: 'ticket.tags.0.value.current',
+      tags1: 'ticket.tags.1.value.current',
+      tags2: 'ticket.tags.2.value.current',
+      tags3: 'ticket.tags.3.value.current',
+      firstMessage: 'ticket.thread.0.content',
+      thread: 'ticket.thread',
+      slug: 'slug.current',
+    },
+    prepare({
+      channelName,
+      status,
+      summary,
+      tags0,
+      tags1,
+      tags2,
+      tags3,
+      firstMessage,
+      thread,
+      slug,
+    }) {
+      const tags = [tags0, tags1, tags2].filter(Boolean);
+      const tagsList = tags.length ? `${tags.join(', ')}` : '[missing tags]';
+      const hasMoreTags = Boolean(tags3);
+      const label =
+        status !== 'resolved' ? (
+          slug ? (
+            <>
+              <Icon emoji="🎫" />
+              <LiveIcon />
+            </>
+          ) : (
+            <Icon emoji="🎫" />
+          )
+        ) : slug ? (
+          <>
+            <Icon emoji="✅" />
+            <LiveIcon />
+          </>
+        ) : (
+          <Icon emoji="✅" />
+        );
+
+      return {
+        title: summary || firstMessage,
+        subtitle: `${channelName ? `#${channelName},` : ''} ${tagsList}${hasMoreTags ? '...' : ''}`,
+        media: label,
+      };
+    },
+  },
+};

--- a/schemas/schema.js
+++ b/schemas/schema.js
@@ -37,6 +37,7 @@ import figure from './objects/figure';
 import contributionTypeSections from './objects/contributionTypeSections';
 import contest from './documents/contest';
 import feedback from './documents/feedback';
+import answerFeedback from './documents/answerFeedback';
 import landingGetStarted from './documents/landingGetStarted';
 import slackAuthor from './documents/slackAuthor';
 
@@ -60,6 +61,7 @@ export default createSchema({
     techPartner,
     contest,
     feedback,
+    answerFeedback,
     landingGetStarted,
 
     // Object types

--- a/schemas/schema.js
+++ b/schemas/schema.js
@@ -7,6 +7,7 @@ import schemaTypes from 'all:part:@sanity/base/schema-type';
 import aggregate from './documents/aggregate';
 import contribution from './documents/contribution';
 import docSearch from './documents/docSearch';
+import editorial from './documents/editorial';
 import emojiTracker from './documents/emojiTracker';
 import person from './documents/person';
 import tag from './documents/tag';
@@ -48,6 +49,7 @@ export default createSchema({
     aggregate,
     contribution,
     docSearch,
+    editorial,
     emojiTracker,
     person,
     tag,


### PR DESCRIPTION
This PR adds feedback to answers in `Community ecosystem > Answer feedback`.

Fixes [GRO-59](https://linear.app/sanity/issue/GRO-59)

There is a corresponding PR in `www-sanity-io` for adding a feedback form to answers: https://github.com/sanity-io/www-sanity-io/pull/1359

Screenshot from my locally running community studio:
![Screenshot 2023-06-30 at 15 45 03](https://github.com/sanity-io/community-studio/assets/207794/40716f6c-1951-4e2f-a757-f73b1e272cf7)

I have one TODO note in this PR, see https://github.com/sanity-io/community-studio/blob/gro-59-answers-page-feedback-module/schemas/documents/answerFeedback.js#L56

I don't really understand the ticket/editorial change. If I understand things correctly:
- Answers were previously saved as the `ticket` document
- We have since run some code to create a new `editorial` item per `ticket`
  - This also copied over some data but also includes a reference to the original `ticket` item
- When a new `ticket` item is created we automatically create a corresponding `editorial` item similar to above

What's most confusing to me is that there is not actually an `editorial` document type defined in the schema. Is it correct that my `answerFeedback` document has a reference to the old `ticket` document type?