### PR TITLE
Feat add community support template

### DIFF
--- a/plugins/desk/adminStructure.ts
+++ b/plugins/desk/adminStructure.ts
@@ -9,6 +9,7 @@ import {
   RocketIcon,
   BillIcon,
   IceCreamIcon,
+  StarIcon,
 } from '@sanity/icons'
 
 import { ConnectionIcon } from '../../schemas/components/icons/ConnectionIcon'
@@ -76,6 +77,22 @@ export const getAdminStructure = (S, context) => [
             .title('Ticket Curation')
             .icon(EnvelopeIcon)
             .child(getSupportStructure(S, context)),
+          S.listItem()
+            .title('Community Support Highlights')
+            .icon(StarIcon)
+            .child(
+              S.documentList('contribution.guide')
+                .title('Community Support Highlights')
+
+                .filter(
+                  `_type == 'contribution.guide' && string::startsWith(title, 'Community Support Highlight')`,
+                )
+                .apiVersion('2023-10-18')
+                .canHandleIntent(S.documentTypeList('contribution.guide').getCanHandleIntent())
+                .menuItems(S.documentTypeList('contribution.guide').getMenuItems())
+                .initialValueTemplates([S.initialValueTemplateItem('communitySupportHighlight')]),
+            ),
+
           S.listItem()
             .title('Community Contributions')
             .icon(GiftIcon)

--- a/plugins/initialValueTemplates.ts
+++ b/plugins/initialValueTemplates.ts
@@ -1,1 +1,28 @@
-export const initialValueTemplates = (T: any) => [...T.defaults()];
+import { InitialValueResolverContext, Template } from 'sanity'
+
+export const initialValueTemplates = (prev, context: InitialValueResolverContext) => {
+  const { currentUser, getClient } = context
+  const client = getClient({ apiVersion: '2024-01-15' })
+
+  if (currentUser?.role == 'administrator') {
+    const communitySupportHighlightTemplate = {
+      id: 'communitySupportHighlight',
+      name: 'Community Support Highlight',
+      schemaType: 'contribution.guide',
+      value: async () => {
+        const authorId = await client.fetch(`*[_id == $id || _id == 'drafts.' + $id][0]._id`, {
+          id: currentUser.id,
+        })
+
+        return {
+          authors: [{ _type: 'reference', _ref: authorId }],
+          title: `Community Support Highlight ${new Date().toLocaleDateString()}`,
+        }
+      },
+    }
+
+    return [...prev, communitySupportHighlightTemplate]
+  }
+
+  return prev
+}

--- a/sanity.config.ts
+++ b/sanity.config.ts
@@ -18,19 +18,19 @@ import { schemaTypes } from './schemas'
 
 const isDev = process.env.NODE_ENV === 'development'
 export default defineConfig({
-  // auth: {
-  //   loginMethod: 'dual',
-  //   redirectOnSingle: false,
-  //   providers: (prev) => [
-  //     // ...(isDev && [...prev]),
-  //     {
-  //       name: 'community',
-  //       title: 'Log in with your Sanity Account',
-  //       url: '/login',
-  //       logo: '/sanity-login.png',
-  //     },
-  //   ],
-  // },
+  auth: {
+    loginMethod: 'dual',
+    redirectOnSingle: false,
+    providers: (prev) => [
+      // ...(isDev && [...prev]),
+      {
+        name: 'community',
+        title: 'Log in with your Sanity Account',
+        url: '/login',
+        logo: '/sanity-login.png',
+      },
+    ],
+  },
   name: 'default',
   title: 'community-studio',
 

--- a/sanity.config.ts
+++ b/sanity.config.ts
@@ -11,25 +11,26 @@ import {
   getDefaultDocumentNode,
   resolveDocumentActions,
   newDocumentOptions,
+  initialValueTemplates,
 } from './plugins'
 import { structure } from './plugins/desk'
 import { schemaTypes } from './schemas'
 
 const isDev = process.env.NODE_ENV === 'development'
 export default defineConfig({
-  auth: {
-    loginMethod: 'dual',
-    redirectOnSingle: false,
-    providers: (prev) => [
-      // ...(isDev && [...prev]),
-      {
-        name: 'community',
-        title: 'Log in with your Sanity Account',
-        url: '/login',
-        logo: '/sanity-login.png',
-      },
-    ],
-  },
+  // auth: {
+  //   loginMethod: 'dual',
+  //   redirectOnSingle: false,
+  //   providers: (prev) => [
+  //     // ...(isDev && [...prev]),
+  //     {
+  //       name: 'community',
+  //       title: 'Log in with your Sanity Account',
+  //       url: '/login',
+  //       logo: '/sanity-login.png',
+  //     },
+  //   ],
+  // },
   name: 'default',
   title: 'community-studio',
 
@@ -61,5 +62,6 @@ export default defineConfig({
   },
   schema: {
     types: schemaTypes,
+    templates: initialValueTemplates,
   },
 })


### PR DESCRIPTION
This commit creates a new document list in the Community Ecosystem section of the Admin Structure with an initial value template that includes a title and automatically sets the author to the current user. 

This has a second commit because I forgot to reenable the `auth` in config after playing around with it  