### PR TITLE
Allow Sanity administrators to delete users in Studio

### DIFF
--- a/plugins/actions/index.ts
+++ b/plugins/actions/index.ts
@@ -2,7 +2,9 @@ import {DocumentActionsResolver} from 'sanity';
 import PublishContributionAction from './publishContributionAction';
 import PublishTicketAction from './publishTicketAction';
 
-export const resolveDocumentActions: DocumentActionsResolver = (prev, {schemaType}) => {
+export const resolveDocumentActions: DocumentActionsResolver = (prev, context) => {
+  const {currentUser, schemaType} = context;
+
   // Contribution documents need a distinct publish action for curatedContribution creation
   if (schemaType.includes('contribution.')) {
     return [PublishContributionAction, ...prev.filter(({action}) => action !== 'publish')];
@@ -13,11 +15,20 @@ export const resolveDocumentActions: DocumentActionsResolver = (prev, {schemaTyp
     return [PublishTicketAction, ...prev.filter(({action}) => action !== 'publish')];
   }
 
+  // Permit Sanity administrators to delete users
+  if (
+    schemaType === 'person' &&
+    currentUser?.roles.some((role) => role?.name === 'administrator') &&
+    currentUser?.email.match(/@sanity\.io$/)
+  ) {
+    return prev;
+  }
+
   // Non-deletable documents
   if (schemaType === 'person' || schemaType === 'taxonomy.contributionType') {
     return [
       ...prev.filter(
-        ({action}) => action !== 'delete' && action !== 'duplicate' && action !== 'unpublish'
+        ({action}) => action !== 'delete' && action !== 'duplicate' && action !== 'unpublish',
       ),
     ];
   }

--- a/plugins/actions/index.ts
+++ b/plugins/actions/index.ts
@@ -28,7 +28,7 @@ export const resolveDocumentActions: DocumentActionsResolver = (prev, context) =
   if (schemaType === 'person' || schemaType === 'taxonomy.contributionType') {
     return [
       ...prev.filter(
-        ({action}) => action !== 'delete' && action !== 'duplicate' && action !== 'unpublish',
+        ({action}) => action !== 'delete' && action !== 'duplicate' && action !== 'unpublish'
       ),
     ];
   }

--- a/plugins/actions/index.ts
+++ b/plugins/actions/index.ts
@@ -19,7 +19,7 @@ export const resolveDocumentActions: DocumentActionsResolver = (prev, context) =
   if (
     schemaType === 'person' &&
     currentUser?.roles.some((role) => role?.name === 'administrator') &&
-    currentUser?.email.match(/@sanity\.io$/)
+    currentUser?.email.endsWith('@sanity.io')
   ) {
     return prev;
   }


### PR DESCRIPTION
Updates the document actions permissions to allow Sanity administrators to delete users from within the Studio. Currently, this must be done using the CLI, which is too cumbersome.