### PR TITLE
Clean up Starter document

### DIFF
--- a/schemas/documents/contributions/starter.tsx
+++ b/schemas/documents/contributions/starter.tsx
@@ -114,7 +114,7 @@ export const starter = {
     },
     {
       title: 'Repository URL',
-      name: 'repoId',
+      name: 'repository',
       description: "The repository URL of your template's GitHub repository",
       type: 'url',
       validation: (rule: Rule) => [

--- a/schemas/documents/contributions/starter.tsx
+++ b/schemas/documents/contributions/starter.tsx
@@ -12,7 +12,7 @@ import {
 } from './contributionUtils'
 
 export const starter = {
-  title: 'Starter',
+  title: 'Template',
   name: 'contribution.starter',
   type: 'document',
   icon: RocketIcon,
@@ -59,6 +59,7 @@ export const starter = {
       type: 'number',
       description: 'Which Sanity Studio version does this template use?',
       initialValue: -1,
+      hidden: true,
       options: {
         layout: 'radio',
         direction: 'horizontal',
@@ -100,8 +101,8 @@ export const starter = {
         layout: 'radio',
         list: [
           { title: 'Vercel', value: 'vercel' },
-          {title: 'Netlify', value: 'netlify'},
-          {title: 'None', value: 'none'},
+          { title: 'Netlify', value: 'netlify' },
+          { title: 'None', value: 'none' },
         ],
       },
       initialValue: 'none',
@@ -111,10 +112,10 @@ export const starter = {
       name: 'netlifyDeployLink',
       description: 'The Netlify Deploy Button link',
       type: 'string',
-      hidden: ({parent}) => parent.deploymentType !== 'netlify',
+      hidden: ({ parent }) => parent.deploymentType !== 'netlify',
       validation: (Rule) =>
         Rule.custom((netlifyLink, context) => {
-          return context.parent.deploymentType === 'netlify' && !netlifyLink ? 'Required' : true;
+          return context.parent.deploymentType === 'netlify' && !netlifyLink ? 'Required' : true
         }),
     },
     {
@@ -122,10 +123,10 @@ export const starter = {
       name: 'vercelDeployLink',
       description: 'The Vercel Deploy Button link',
       type: 'string',
-      hidden: ({parent}) => parent.deploymentType !== 'vercel',
+      hidden: ({ parent }) => parent.deploymentType !== 'vercel',
       validation: (Rule) =>
         Rule.custom((vercelLink, context) => {
-          return context.parent.deploymentType === 'vercel' && !vercelLink ? 'Required' : true;
+          return context.parent.deploymentType === 'vercel' && !vercelLink ? 'Required' : true
         }),
     },
     {

--- a/schemas/documents/contributions/starter.tsx
+++ b/schemas/documents/contributions/starter.tsx
@@ -175,43 +175,6 @@ export const starter = {
           return true
         }),
     },
-    {
-      name: 'showAgencyContactLink',
-      title: 'Show agency contact information',
-      description: "Display a card on the template page with a link to your agency's website.",
-      type: 'boolean',
-      defaultValue: false,
-    },
-    {
-      name: 'agencyName',
-      title: 'Agency name',
-      description: 'The name of the agency that maintains this template.',
-      type: 'string',
-      hidden: ({ parent }: any) => !parent.showAgencyContactLink,
-      validation: (rule: Rule) =>
-        rule.custom(async (agencyName, context: any) => {
-          if (!agencyName && context.parent.showAgencyContactLink) {
-            return 'Required'
-          }
-
-          return true
-        }),
-    },
-    {
-      name: 'agencyContactUrl',
-      title: 'Agency contact URL',
-      description: "The URL to your agency's contact page.",
-      type: 'url',
-      hidden: ({ parent }: any) => !parent.showAgencyContactLink,
-      validation: (rule: Rule) =>
-        rule.custom(async (agencyContactUrl, context: any) => {
-          if (!agencyContactUrl && context.parent.showAgencyContactLink) {
-            return 'Required'
-          }
-
-          return true
-        }),
-    },
     //V3FIXME
     ogImageField,
     publishedAtField,

--- a/schemas/documents/contributions/starter.tsx
+++ b/schemas/documents/contributions/starter.tsx
@@ -23,7 +23,7 @@ export const starter = {
       title: 'Message for editors',
       type: 'string',
       readOnly: true,
-      hidden: ({ parent }: any) => parent.studioVersion === 3 || parent.studioVersion === undefined,
+      hidden: true,
       //V3FIXME
       inputComponent: forwardRef(() => {
         return (
@@ -131,60 +131,17 @@ export const starter = {
     },
     {
       title: 'Repository URL',
-      name: 'repository',
-      description:
-        'The URL for your repository. E.g. https://github.com/sanity-io/sanity-template-example',
-      type: 'url',
-      hidden: ({ parent }: any) => parent.studioVersion === 2 || parent.studioVersion === -1,
-      validation: (rule: Rule) =>
-        rule.custom(async (repository, context: any) => {
-          if (!repository && context.parent.studioVersion === 3) {
-            return 'Required'
-          }
-
-          return true
-        }),
-    },
-    {
-      title: 'Repository URL',
       name: 'repoId',
-      description:
-        "The repo ID or slug from your template's GitHub repository (eg. sanity-io/sanity-template-example)",
-      type: 'string',
-      hidden: ({ parent }: any) => parent.studioVersion === 3,
+      description: "The repository URL of your template's GitHub repository",
+      type: 'url',
       validation: (rule: Rule) => [
         // Ensure that the repo id field
-        rule.custom(async (repoId, context: any) => {
-          if (
-            !repoId &&
-            context.parent.deploymentType === 'sanityCreate' &&
-            (context.parent.studioVersion === 2 || context.parent.studioVersion === -1)
-          ) {
-            return 'Required'
-          }
+        rule.required(),
 
-          return true
-        }),
-
-        // Ensure repo is compatible with sanity.io/create
-        rule.custom(async (repoId, context: any) => {
-          if (
-            !repoId ||
-            (context.parent.deploymentType === 'sanityCreate' &&
-              (context.parent.studioVersion === 2 || context.parent.studioVersion === -1))
-          ) {
-            return true
-          }
-          const res = await fetch(`/api/validate-starter?repoId=${repoId}`)
-          if (res.status === 200) {
-            // @ts-expect-error
-            window._starterValidity = true
-            return true
-          }
-          // @ts-expect-error
-          window._starterValidity = false
-          return "Sanity.io/create couldn't validate your template."
-        }),
+        // TODO: Update for running API call to validate template with template validator
+        // rule.custom(async (repoId, context: any) => {
+        //   return true
+        // }),
       ],
     },
     {
@@ -192,15 +149,6 @@ export const starter = {
       name: 'demoURL',
       description: "URL of your template's demo. E.g. https://demo.vercel.store",
       type: 'url',
-      hidden: ({ parent }: any) => parent.studioVersion === 2 || parent.studioVersion === -1,
-      validation: (rule: Rule) =>
-        rule.custom(async (demoUrl, context: any) => {
-          if (!demoUrl && context.parent.studioVersion === 3) {
-            return 'Required'
-          }
-
-          return true
-        }),
     },
     {
       title: '📷 Main image',
@@ -260,7 +208,7 @@ export const starter = {
       name: 'companyContactUrl',
       title: 'Company contact URL',
       description: "The URL to your company's contact page.",
-      type: 'string',
+      type: 'url',
       hidden: ({ parent }: any) => !parent.showCompanyContactLink,
       validation: (rule: Rule) =>
         rule.custom(async (companyContactUrl, context: any) => {

--- a/schemas/documents/contributions/starter.tsx
+++ b/schemas/documents/contributions/starter.tsx
@@ -130,6 +130,14 @@ export const starter = {
       ],
     },
     {
+      title: 'Repository URL',
+      name: 'repoId',
+      description:
+        "The repo ID or slug from your template's GitHub repository (eg. sanity-io/sanity-template-example)",
+      type: 'string',
+      hidden: true,
+    },
+    {
       title: 'Demo URL',
       name: 'demoURL',
       description: "URL of your template's demo. E.g. https://demo.vercel.store",

--- a/schemas/documents/contributions/starter.tsx
+++ b/schemas/documents/contributions/starter.tsx
@@ -75,8 +75,10 @@ export const starter = {
           return true
         }),
     },
+    // Hidden. No longer used.
     {
       name: 'deploymentType',
+      hidden: true,
       title: 'What deployment option do you want to use?',
       description: 'Choose the deployment type for this project',
       type: 'string',
@@ -206,16 +208,18 @@ export const starter = {
     ogImageField,
     publishedAtField,
     ...getContributionTaxonomies('starter', {
+      // Hidden. Duplicate of usecases
       solutions: {
-        title: 'Categories',
+        title: 'Use case',
         description: 'Connect your template to common themes in the Sanity community.',
-        hidden: ({ parent }: any) => parent.studioVersion === 3,
+        hidden: true,
       },
+      // Hidden. Not used
       categories: {
-        title: 'Categories',
+        title: 'Template type',
         description:
           'Connect your template to common themes in the Sanity community. Let us know if you have more great category ideas.',
-        hidden: ({ parent }: any) => parent.studioVersion === 3,
+        hidden: true,
       },
       frameworks: {
         title: 'Application frameworks',
@@ -253,7 +257,6 @@ export const starter = {
       usecases: {
         title: 'Use case',
         description: 'e.g. Ecommerce',
-        hidden: ({ parent }: any) => parent.studioVersion === 2 || parent.studioVersion === -1,
         validation: (rule: Rule) =>
           rule.custom(async (usecase: any, context: any) => {
             if (
@@ -267,17 +270,19 @@ export const starter = {
             return true
           }),
       },
+      // Hidden. Not used
       integrations: {
         title: 'Integrations & services used',
         description:
           'If your tool connects Sanity to other services and APIs. If you can’t find what you’re after get in touch.',
-        hidden: ({ parent }: any) => parent.studioVersion === 3,
+        hidden: true,
       },
+      // Hidden. Not used
       tools: {
         title: 'Sanity tools this template relies on',
         description:
           'Browse for plugins, asset sources, SDKs and other dependencies used in this template.',
-        hidden: ({ parent }: any) => parent.studioVersion === 3,
+        hidden: true,
       },
     }),
   ],

--- a/schemas/documents/contributions/starter.tsx
+++ b/schemas/documents/contributions/starter.tsx
@@ -132,7 +132,7 @@ export const starter = {
     {
       title: 'Repository URL',
       name: 'repoId',
-      description: "The repository URL of your template's GitHub repository",
+      description: "The URL of your template's GitHub repository",
       type: 'url',
       validation: (rule: Rule) => [
         // Ensure that the repo id field

--- a/schemas/documents/contributions/starter.tsx
+++ b/schemas/documents/contributions/starter.tsx
@@ -166,21 +166,21 @@ export const starter = {
         }),
     },
     {
-      name: 'showCompanyContactLink',
-      title: 'Show company contact information',
-      description: "Display a card on the template page with a link to your company's website.",
+      name: 'showAgencyContactLink',
+      title: 'Show agency contact information',
+      description: "Display a card on the template page with a link to your agency's website.",
       type: 'boolean',
       defaultValue: false,
     },
     {
-      name: 'companyName',
-      title: 'Company name',
-      description: 'The name of the company that maintains this template.',
+      name: 'agencyName',
+      title: 'Agency name',
+      description: 'The name of the agency that maintains this template.',
       type: 'string',
-      hidden: ({ parent }: any) => !parent.showCompanyContactLink,
+      hidden: ({ parent }: any) => !parent.showAgencyContactLink,
       validation: (rule: Rule) =>
-        rule.custom(async (companyName, context: any) => {
-          if (!companyName && context.parent.showCompanyContactLink) {
+        rule.custom(async (agencyName, context: any) => {
+          if (!agencyName && context.parent.showAgencyContactLink) {
             return 'Required'
           }
 
@@ -188,14 +188,14 @@ export const starter = {
         }),
     },
     {
-      name: 'companyContactUrl',
-      title: 'Company contact URL',
-      description: "The URL to your company's contact page.",
+      name: 'agencyContactUrl',
+      title: 'Agency contact URL',
+      description: "The URL to your agency's contact page.",
       type: 'url',
-      hidden: ({ parent }: any) => !parent.showCompanyContactLink,
+      hidden: ({ parent }: any) => !parent.showAgencyContactLink,
       validation: (rule: Rule) =>
-        rule.custom(async (companyContactUrl, context: any) => {
-          if (!companyContactUrl && context.parent.showCompanyContactLink) {
+        rule.custom(async (agencyContactUrl, context: any) => {
+          if (!agencyContactUrl && context.parent.showAgencyContactLink) {
             return 'Required'
           }
 

--- a/schemas/documents/contributions/starter.tsx
+++ b/schemas/documents/contributions/starter.tsx
@@ -234,6 +234,43 @@ export const starter = {
           return true
         }),
     },
+    {
+      name: 'showCompanyContactLink',
+      title: 'Show company contact information',
+      description: "Display a card on the template page with a link to your company's website.",
+      type: 'boolean',
+      defaultValue: false,
+    },
+    {
+      name: 'companyName',
+      title: 'Company name',
+      description: 'The name of the company that maintains this template.',
+      type: 'string',
+      hidden: ({ parent }: any) => !parent.showCompanyContactLink,
+      validation: (rule: Rule) =>
+        rule.custom(async (companyName, context: any) => {
+          if (!companyName && context.parent.showCompanyContactLink) {
+            return 'Required'
+          }
+
+          return true
+        }),
+    },
+    {
+      name: 'companyContactUrl',
+      title: 'Company contact URL',
+      description: "The URL to your company's contact page.",
+      type: 'string',
+      hidden: ({ parent }: any) => !parent.showCompanyContactLink,
+      validation: (rule: Rule) =>
+        rule.custom(async (companyContactUrl, context: any) => {
+          if (!companyContactUrl && context.parent.showCompanyContactLink) {
+            return 'Required'
+          }
+
+          return true
+        }),
+    },
     //V3FIXME
     ogImageField,
     publishedAtField,

--- a/schemas/documents/contributions/starter.tsx
+++ b/schemas/documents/contributions/starter.tsx
@@ -19,23 +19,6 @@ export const starter = {
   initialValue: contributionInitialValue,
   fields: [
     {
-      name: 'warningv2',
-      title: 'Message for editors',
-      type: 'string',
-      readOnly: true,
-      hidden: true,
-      //V3FIXME
-      inputComponent: forwardRef(() => {
-        return (
-          <Card padding={3} radius={1} shadow={1} tone="caution">
-            <Text align="center" size={1} weight="semibold">
-              v2 templates are no longer supported
-            </Text>
-          </Card>
-        )
-      }),
-    },
-    {
       title: 'Title',
       name: 'title',
       type: 'string',
@@ -132,16 +115,16 @@ export const starter = {
     {
       title: 'Repository URL',
       name: 'repoId',
-      description: "The URL of your template's GitHub repository",
+      description: "The repository URL of your template's GitHub repository",
       type: 'url',
       validation: (rule: Rule) => [
         // Ensure that the repo id field
         rule.required(),
 
         // TODO: Update for running API call to validate template with template validator
-        // rule.custom(async (repoId, context: any) => {
-        //   return true
-        // }),
+        rule.custom(async (repoId, context: any) => {
+          return true
+        }),
       ],
     },
     {


### PR DESCRIPTION
This PR cleans up the `starter` document in preparation for new Template workflow.


Hides/Removes unused or duplicate fields:
- `warningv2`
- `deploymentType`
- `repoId` in favor of `repository`
- `solutions` (duplicate of `usecases`)
- `categories` (unused template type field)

<img width="338" alt="image" src="https://github.com/user-attachments/assets/50c161bb-05a3-4ba4-8a21-11c63d1e831b" />
