### PR TITLE
chore: say yes automatically to autoupdate question

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "_dev": "ts-node-dev src/dev.ts --respawn --transpileOnly",
     "dev": "sanity dev",
     "start": "sanity start",
-    "build": "sanity build",
+    "build": "sanity build -y",
     "deploy": "sanity deploy",
     "deploy-graphql": "sanity graphql deploy",
     "lint": "run-p lint:*",


### PR DESCRIPTION
Adds the `-y` flag to the `sanity build` script so that it skips the warning about mismatched versions at run and build time