### PR TITLE
Update default studioVersion for starter documents to 3

### DIFF
--- a/schemas/documents/contributions/starter.tsx
+++ b/schemas/documents/contributions/starter.tsx
@@ -41,7 +41,7 @@ export const starter = {
       title: 'Studio version',
       type: 'number',
       description: 'Which Sanity Studio version does this template use?',
-      initialValue: -1,
+      initialValue: 3,
       hidden: true,
       options: {
         layout: 'radio',

--- a/schemas/documents/contributions/starter.tsx
+++ b/schemas/documents/contributions/starter.tsx
@@ -65,7 +65,6 @@ export const starter = {
         basePath: 'sanity.io/templates',
         source: 'title',
       },
-      hidden: ({ parent }: any) => parent.studioVersion === 2 || parent.studioVersion === -1,
       validation: (rule: Rule) =>
         rule.custom(async (slug, context: any) => {
           if (!slug && context.parent.studioVersion === 3) {


### PR DESCRIPTION
- Updates `starter`(template) document's default `studioVersion` value to be `3` instead of `-1`
- Also doesn't hide the `slug` field based on the deprecated `studioVersion` field

