### PR TITLE
feat: remove slug when duplicating contribution documents

### DIFF
--- a/plugins/actions/duplicateWithoutSlugAction.ts
+++ b/plugins/actions/duplicateWithoutSlugAction.ts
@@ -1,0 +1,12 @@
+import { DuplicateDocumentActionComponent } from 'sanity'
+
+export function createDuplicateWithoutSlugAction(
+  originalAction: DuplicateDocumentActionComponent,
+): DuplicateDocumentActionComponent {
+  return function DuplicateWithoutSlugAction(props) {
+    return originalAction({
+      ...props,
+      mapDocument: ({ slug, ...document }) => document,
+    })
+  }
+}

--- a/plugins/actions/index.ts
+++ b/plugins/actions/index.ts
@@ -1,13 +1,23 @@
 import { DocumentActionsResolver } from 'sanity'
 import PublishContributionAction from './publishContributionAction'
 import PublishTicketAction from './publishTicketAction'
+import { createDuplicateWithoutSlugAction } from './duplicateWithoutSlugAction'
 
 export const resolveDocumentActions: DocumentActionsResolver = (prev, context) => {
   const { currentUser, schemaType } = context
 
   // Contribution documents need a distinct publish action for curatedContribution creation
   if (schemaType.includes('contribution.')) {
-    return [PublishContributionAction, ...prev.filter(({ action }) => action !== 'publish')]
+    return [
+      PublishContributionAction, 
+      ...prev
+        .filter(({ action }) => action !== 'publish')
+        .map((actionItem) => 
+          actionItem.action === 'duplicate' 
+            ? createDuplicateWithoutSlugAction(actionItem) 
+            : actionItem
+        )
+    ]
   }
 
   // Tickets have an auto-generated slug, hence the custom publish action


### PR DESCRIPTION
## Summary
- Implements custom duplicate action that automatically removes `slug.current` field when duplicating contribution documents
- Prevents slug conflicts when duplicating recipes, guides, showcase projects, templates, and tools  
- Uses Sanity v3.91.0's new `mapDocument` feature for clean document transformation

## Test plan
- [ ] Test duplicating a recipe document
- [ ] Test duplicating a guide document  
- [ ] Test duplicating a showcase project
- [ ] Test duplicating a template
- [ ] Test duplicating a tool
- [ ] Verify slug field is cleared in all duplicated documents
- [ ] Confirm other document fields are preserved during duplication

🤖 Generated with [Claude Code](https://claude.ai/code)