### PR TITLE
feat: make repository URL optional for paid templates

### DIFF
--- a/schemas/documents/contributions/starter.tsx
+++ b/schemas/documents/contributions/starter.tsx
@@ -150,6 +150,13 @@ export const starter = {
       type: 'url',
     },
     {
+      title: 'Page content',
+      name: 'body',
+      type: 'guideBody',
+      description:
+        'Optional: Describe your template in detail. If a Repository URL is provided, the README will be shown instead.',
+    },
+    {
       title: '📷 Main image',
       name: 'image',
       description: 'An image or screenshot of your template. 1200px wide x 750px high is ideal.',

--- a/schemas/documents/contributions/starter.tsx
+++ b/schemas/documents/contributions/starter.tsx
@@ -116,14 +116,14 @@ export const starter = {
     {
       title: 'Repository URL',
       name: 'repository',
-      description: "The repository URL of your template's GitHub repository",
+      description:
+        "The repository URL of your template's GitHub repository. Required for non-commercial templates, optional if a Purchase URL is provided.",
       type: 'url',
       validation: (rule: Rule) => [
-        // Ensure that the repo id field
-        rule.required(),
-
-        // TODO: Update for running API call to validate template with template validator
-        rule.custom(async (repoId, context: any) => {
+        rule.custom((repository, context: any) => {
+          if (!repository && !context.parent?.purchaseUrl) {
+            return 'Required (unless a Purchase URL is provided)'
+          }
           return true
         }),
       ],
@@ -146,7 +146,7 @@ export const starter = {
       title: 'Purchase URL',
       name: 'purchaseUrl',
       description:
-        "Optional: If you're selling your template, please include a link to the purchase page here.  You'll still need to include a Repository URL above, as that is where content is pulled from.  You can just include a README.md in that repository, if you'd like",
+        "Optional: If you're selling your template, please include a link to the purchase page here.",
       type: 'url',
     },
     {


### PR DESCRIPTION
## Summary

- Makes the `repository` field on `contribution.starter` conditionally required instead of always required
- When a `purchaseUrl` is provided, `repository` becomes optional — allowing paid template authors to list without a public GitHub repo
- Updates the `purchaseUrl` field description to remove the outdated note about still needing a Repository URL

## Companion PR

The frontend (www-sanity-io) needs a companion PR to guard against missing `repository` values — otherwise paid templates without a repo URL will crash.

## Test plan

- [ ] Open the studio locally with `pnpm dev`
- [ ] Create/edit a template document:
  - [ ] Verify that removing both `repository` and `purchaseUrl` shows a validation error
  - [ ] Verify that adding only `purchaseUrl` clears the repository validation error
  - [ ] Verify that adding only `repository` (no `purchaseUrl`) still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)